### PR TITLE
Converting field name to camel cases only if "_" exists in the name

### DIFF
--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/ProtoToGql.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/ProtoToGql.java
@@ -147,12 +147,14 @@ final class ProtoToGql {
 
     @Override
     public GraphQLFieldDefinition apply(FieldDescriptor fieldDescriptor) {
+      String fieldName = fieldDescriptor.getName();
+      String convertedFieldName = fieldName.contains("_") ? UNDERSCORE_TO_CAMEL.convert(fieldName) : fieldName;
       GraphQLFieldDefinition.Builder builder =
           GraphQLFieldDefinition.newFieldDefinition()
               .type(convertType(fieldDescriptor))
               .dataFetcher(
-                  new ProtoDataFetcher(UNDERSCORE_TO_CAMEL.convert(fieldDescriptor.getName())))
-              .name(UNDERSCORE_TO_CAMEL.convert(fieldDescriptor.getName()));
+                  new ProtoDataFetcher(convertedFieldName))
+              .name(convertedFieldName);
       if (fieldDescriptor.getFile().toProto().getSourceCodeInfo().getLocationCount()
           > fieldDescriptor.getIndex()) {
         builder.description(

--- a/rejoiner/src/test/java/com/google/api/graphql/rejoiner/ProtoToGqlTest.java
+++ b/rejoiner/src/test/java/com/google/api/graphql/rejoiner/ProtoToGqlTest.java
@@ -21,6 +21,7 @@ import com.google.api.graphql.rejoiner.TestProto.Proto1.InnerProto;
 import com.google.api.graphql.rejoiner.TestProto.Proto2;
 import com.google.api.graphql.rejoiner.TestProto.Proto2.TestEnum;
 import graphql.schema.GraphQLEnumType;
+import graphql.schema.GraphQLEnumValueDefinition;
 import graphql.schema.GraphQLObjectType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,7 +56,7 @@ public final class ProtoToGqlTest {
     GraphQLObjectType result = ProtoToGql.convert(Proto1.getDescriptor(), null);
     assertThat(result.getName())
         .isEqualTo("javatests_com_google_api_graphql_rejoiner_proto_Proto1");
-    assertThat(result.getFieldDefinitions()).hasSize(4);
+    assertThat(result.getFieldDefinitions()).hasSize(5);
   }
 
   @Test
@@ -64,8 +65,16 @@ public final class ProtoToGqlTest {
     assertThat(result.getName())
         .isEqualTo("javatests_com_google_api_graphql_rejoiner_proto_Proto2_TestEnum");
     assertThat(result.getValues()).hasSize(3);
-    assertThat(result.getValues().stream().map(a -> a.getName()).toArray())
+    assertThat(result.getValues().stream().map(GraphQLEnumValueDefinition::getName).toArray())
         .asList()
         .containsExactly("UNKNOWN", "FOO", "BAR");
+  }
+
+  @Test
+  public void checkFieldNameCamelCase() {
+    GraphQLObjectType result = ProtoToGql.convert(Proto1.getDescriptor(), null);
+    assertThat(result.getFieldDefinitions()).hasSize(5);
+    assertThat(result.getFieldDefinition("intField")).isNotNull();
+    assertThat(result.getFieldDefinition("camelCaseName")).isNotNull();
   }
 }

--- a/rejoiner/src/test/proto/test_proto.proto
+++ b/rejoiner/src/test/proto/test_proto.proto
@@ -23,6 +23,7 @@ message Proto1 {
   int64 int_field = 2;
   Proto2 test_proto = 3;
   InnerProto test_inner_proto = 4;
+  int64 camelCaseName = 5;
 
   message InnerProto {
     string foo = 1;


### PR DESCRIPTION
It's an issue with GRPC result type field name converting. All fields are converting using
`UNDERSCORE_TO_CAMEL.convert(fieldDescriptor.getName())` in `ProtoToGql` class even if the field name doesn't contains "_" so it's causing a couple of problems:
1. incorrect camel case transformation: 'someTestField' -> 'sometestfield'
2. incorrect value binding GRPC -> GraphQL, lowercased field is always `null`