### PR TITLE
Mark GraphQLList elements as GraphQLNonNull

### DIFF
--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaModule.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaModule.java
@@ -36,6 +36,7 @@ import graphql.schema.DataFetchingEnvironmentBuilder;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLScalarType;
@@ -460,7 +461,7 @@ public abstract class SchemaModule extends AbstractModule {
       Descriptor responseDescriptor =
           (Descriptor) responseClass.getMethod("getDescriptor").invoke(null);
       referencedDescriptors.add(responseDescriptor);
-      return new GraphQLList(ProtoToGql.getReference(responseDescriptor));
+      return new GraphQLList(new GraphQLNonNull(ProtoToGql.getReference(responseDescriptor)));
     }
 
     // ImmutableList<? extends Message>
@@ -470,7 +471,7 @@ public abstract class SchemaModule extends AbstractModule {
       Descriptor responseDescriptor =
           (Descriptor) responseClass.getMethod("getDescriptor").invoke(null);
       referencedDescriptors.add(responseDescriptor);
-      return new GraphQLList(ProtoToGql.getReference(responseDescriptor));
+      return new GraphQLList(new GraphQLNonNull(ProtoToGql.getReference(responseDescriptor)));
     }
 
     // ListenableFuture<? extends Message>

--- a/rejoiner/src/test/java/com/google/api/graphql/rejoiner/RejoinerIntegrationTest.java
+++ b/rejoiner/src/test/java/com/google/api/graphql/rejoiner/RejoinerIntegrationTest.java
@@ -26,7 +26,9 @@ import com.google.inject.Guice;
 import com.google.inject.Key;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLSchema;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,6 +50,11 @@ public final class RejoinerIntegrationTest {
     ListenableFuture<ImmutableList<ExtraProto>> listOfStuff() {
       return Futures.immediateFuture(
           ImmutableList.of(ExtraProto.newBuilder().setSomeValue("1").build()));
+    }
+
+    @Query("listOfStuffSync")
+    ImmutableList<ExtraProto> listOfStuffSync() {
+      return ImmutableList.of(ExtraProto.newBuilder().setSomeValue("1").build());
     }
 
     @Query("greeting")
@@ -77,13 +84,21 @@ public final class RejoinerIntegrationTest {
 
   @Test
   public void schemaShouldHaveOneQuery() {
-    assertThat(schema.getQueryType().getFieldDefinitions()).hasSize(3);
+    assertThat(schema.getQueryType().getFieldDefinitions()).hasSize(4);
   }
 
   @Test
   public void schemaShouldList() {
-    assertThat(schema.getQueryType().getFieldDefinition("listOfStuff").getType())
-        .isInstanceOf(GraphQLList.class);
+    GraphQLOutputType listOfStuff = schema.getQueryType().getFieldDefinition("listOfStuff").getType();
+    assertThat(listOfStuff).isInstanceOf(GraphQLList.class);
+    assertThat(((GraphQLList)listOfStuff).getWrappedType()).isInstanceOf(GraphQLNonNull.class);
+  }
+
+  @Test
+  public void schemaShouldListSync() {
+    GraphQLOutputType listOfStuff = schema.getQueryType().getFieldDefinition("listOfStuffSync").getType();
+    assertThat(listOfStuff).isInstanceOf(GraphQLList.class);
+    assertThat(((GraphQLList)listOfStuff).getWrappedType()).isInstanceOf(GraphQLNonNull.class);
   }
 
   @Test


### PR DESCRIPTION
ImmutableList doesn't allow null values. Given this the schema by default for lists should be defined as Non-Nullable.