### PR TITLE
Handle InvocationException correctly

### DIFF
--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaModule.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaModule.java
@@ -394,6 +394,12 @@ public abstract class SchemaModule extends AbstractModule {
             }
             try {
               return method.invoke(this, methodParameterValues);
+            } catch (InvocationTargetException e) {
+              Throwable cause = e.getCause();
+              if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+              }
+              throw new RuntimeException(cause);
             } catch (Exception e) {
               throw new RuntimeException(e);
             }


### PR DESCRIPTION
When method.invoke throws an InvocationTargetException the original exception is hidden in the cause of this exception. The SchemaModule then wraps that with another RuntimeException.

Because of these the correct error never reached the GraphQL Execution.

When gRPC service throws:
```
throw Status.UNIMPLEMENTED
                .withDescription("message from service")
                .asRuntimeException();
```

The messages below gets rendered on the error.

Before:
```
Exception while fetching data (/greetingWithException) : java.lang.reflect.InvocationTargetException
```

After:
```
Exception while fetching data (/greetingWithException) : UNIMPLEMENTED: message from service
```

I also added a test case to check whether GraphQLError is also handled correctly.