### PR TITLE
Fix example links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 
 These features are actively being developed.
 
- - Relay support [[Example](./examples/java/com/google/api/graphql/examples/library)]
- - GraphQL Stream (based on gRPC streaming) [[Example](./examples/java/com/google/api/graphql/examples/streaming)]
+ - Relay support [[Example](./examples/src/main/java/com/google/api/graphql/examples/library)]
+ - GraphQL Stream (based on gRPC streaming) [[Example](./examples/src/main/java/com/google/api/graphql/examples/streaming)]
 
 ## Schema Module
 


### PR DESCRIPTION
Looks like these probably broke when f7337b8f0b2b4192f95004a96a8ec0f99d75e1e0 changed the directory layout.