### PR TITLE
Using field's Json name instead of internal conversion from snake cas…

### DIFF
--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/GqlInputConverter.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/GqlInputConverter.java
@@ -50,9 +50,6 @@ final class GqlInputConverter {
   private final BiMap<String, Descriptor> descriptorMapping;
   private final BiMap<String, EnumDescriptor> enumMapping;
 
-  private static final Converter<String, String> UNDERSCORE_TO_CAMEL =
-      CaseFormat.LOWER_UNDERSCORE.converterTo(CaseFormat.LOWER_CAMEL);
-
   private GqlInputConverter(
       BiMap<String, Descriptor> descriptorMapping, BiMap<String, EnumDescriptor> enumMapping) {
     this.descriptorMapping = descriptorMapping;
@@ -72,7 +69,7 @@ final class GqlInputConverter {
 
     Map<String, Object> remainingInput = new HashMap<>(input);
     for (FieldDescriptor field : descriptor.getFields()) {
-      String fieldName = getFieldName(field);
+      String fieldName = field.getJsonName();
 
       if (!remainingInput.containsKey(fieldName)) {
         // TODO: validate required fields
@@ -107,7 +104,7 @@ final class GqlInputConverter {
     for (FieldDescriptor field : descriptor.getFields()) {
       GraphQLType fieldType = getFieldType(field);
       GraphQLInputObjectField.Builder inputBuilder =
-          GraphQLInputObjectField.newInputObjectField().name(getFieldName(field));
+          GraphQLInputObjectField.newInputObjectField().name(field.getJsonName());
       if (field.isRepeated()) {
         inputBuilder.type(new GraphQLList(fieldType));
       } else {
@@ -143,12 +140,6 @@ final class GqlInputConverter {
 
   static String getReferenceName(GenericDescriptor descriptor) {
     return "Input_" + ProtoToGql.getReferenceName(descriptor);
-  }
-
-  /** Field names with under_scores are converted to camelCase. */
-  private String getFieldName(FieldDescriptor field) {
-    String fieldName = field.getName();
-    return fieldName.contains("_") ? UNDERSCORE_TO_CAMEL.convert(fieldName) : fieldName;
   }
 
   private GraphQLType getFieldType(FieldDescriptor field) {

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/ProtoToGql.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/ProtoToGql.java
@@ -77,8 +77,6 @@ final class ProtoToGql {
           .put(Type.SFIXED64, Scalars.GraphQLLong)
           .build();
 
-  private static final Converter<String, String> UNDERSCORE_TO_CAMEL =
-      CaseFormat.LOWER_UNDERSCORE.converterTo(CaseFormat.LOWER_CAMEL);
   private static final Converter<String, String> LOWER_CAMEL_TO_UPPER =
       CaseFormat.LOWER_CAMEL.converterTo(CaseFormat.UPPER_CAMEL);
   private static final FieldConverter FIELD_CONVERTER = new FieldConverter();
@@ -147,14 +145,13 @@ final class ProtoToGql {
 
     @Override
     public GraphQLFieldDefinition apply(FieldDescriptor fieldDescriptor) {
-      String fieldName = fieldDescriptor.getName();
-      String convertedFieldName = fieldName.contains("_") ? UNDERSCORE_TO_CAMEL.convert(fieldName) : fieldName;
+      String fieldName = fieldDescriptor.getJsonName();
       GraphQLFieldDefinition.Builder builder =
           GraphQLFieldDefinition.newFieldDefinition()
               .type(convertType(fieldDescriptor))
               .dataFetcher(
-                  new ProtoDataFetcher(convertedFieldName))
-              .name(convertedFieldName);
+                  new ProtoDataFetcher(fieldName))
+              .name(fieldName);
       if (fieldDescriptor.getFile().toProto().getSourceCodeInfo().getLocationCount()
           > fieldDescriptor.getIndex()) {
         builder.description(

--- a/rejoiner/src/test/java/com/google/api/graphql/rejoiner/GqlInputConverterTest.java
+++ b/rejoiner/src/test/java/com/google/api/graphql/rejoiner/GqlInputConverterTest.java
@@ -20,11 +20,13 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.truth.Truth;
 import com.google.common.truth.extensions.proto.ProtoTruth;
 import com.google.protobuf.Message;
-import graphql.schema.GraphQLArgument;
-import graphql.schema.GraphQLInputObjectType;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLInputObjectType;
 
 /** Unit tests for {@link com.google.api.graphql.rejoiner.GqlInputConverter}. */
 @RunWith(JUnit4.class)
@@ -53,6 +55,17 @@ public final class GqlInputConverterTest {
                 .setIntField(123)
                 .setTestProto(Proto2.newBuilder().setInnerId("1").build())
                 .build());
+  }
+
+  @Test(expected = AssertionError.class)
+  public void inputConverterShouldFillProtoBufAllFields() {
+    GqlInputConverter inputConverter =
+        GqlInputConverter.newBuilder().add(TestProto.getDescriptor().getFile()).build();
+    inputConverter.createProtoBuf(
+        Proto1.getDescriptor(),
+        Proto1.newBuilder(),
+        ImmutableMap.of(
+            "id", "id", "intField", 123, "test_proto", ImmutableMap.of("innerId", "1")));
   }
 
   @Test

--- a/rejoiner/src/test/java/com/google/api/graphql/rejoiner/GqlInputConverterTest.java
+++ b/rejoiner/src/test/java/com/google/api/graphql/rejoiner/GqlInputConverterTest.java
@@ -16,6 +16,7 @@ package com.google.api.graphql.rejoiner;
 
 import com.google.api.graphql.rejoiner.TestProto.Proto1;
 import com.google.api.graphql.rejoiner.TestProto.Proto2;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.truth.Truth;
 import com.google.common.truth.extensions.proto.ProtoTruth;
@@ -47,13 +48,17 @@ public final class GqlInputConverterTest {
             Proto1.getDescriptor(),
             Proto1.newBuilder(),
             ImmutableMap.of(
-                "id", "id", "intField", 123, "testProto", ImmutableMap.of("innerId", "1")));
+                "id", "id", "intField", 123, "testProto",
+                ImmutableMap.of("innerId", "1", "enums", ImmutableList.of(Proto2.TestEnum.FOO, Proto2.TestEnum.BAR))));
     ProtoTruth.assertThat(protoBuf)
         .isEqualTo(
             Proto1.newBuilder()
                 .setId("id")
                 .setIntField(123)
-                .setTestProto(Proto2.newBuilder().setInnerId("1").build())
+                .setTestProto(Proto2.newBuilder().setInnerId("1")
+                    .addEnums(Proto2.TestEnum.FOO)
+                    .addEnums(Proto2.TestEnum.BAR)
+                    .build())
                 .build());
   }
 


### PR DESCRIPTION
I'm proposing to use internal `FieldDescriptor` JSON name 
(`Descriptors.fieldNameToJsonName(..)` under the hood) instead of using custom snake to camel case converters, so it will be one source of truth for the field naming. As for now we already have multiple repeated places in the code to do a transformation and one time we missed that already.

P.S. Not sure that I found all places in the code where name getting should be modified as well.