### PR TITLE
Propagate comments from protobuf to GraphQL schema

### DIFF
--- a/rejoiner/pom.xml
+++ b/rejoiner/pom.xml
@@ -247,6 +247,11 @@
        <version>0.5.1</version>
        <configuration>
          <protocExecutable>/usr/local/bin/protoc</protocExecutable>
+         <writeDescriptorSet>true</writeDescriptorSet>
+         <descriptorSetFileName>descriptor_set.desc</descriptorSetFileName>
+         <descriptorSetOutputDirectory>${build.directory}/test-classes/META-INF/proto</descriptorSetOutputDirectory>
+         <includeSourceInfoInDescriptorSet>true</includeSourceInfoInDescriptorSet>
+         <includeDependenciesInDescriptorSet>true</includeDependenciesInDescriptorSet>
        </configuration>
        <executions>
          <execution>

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/DescriptorSet.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/DescriptorSet.java
@@ -1,0 +1,132 @@
+package com.google.api.graphql.rejoiner;
+
+import com.google.protobuf.DescriptorProtos;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+class DescriptorSet {
+  private static final String DEFAULT_DESCRIPTOR_SET_FILE_LOCATION = "META-INF/proto/descriptor_set.desc";
+
+  static final Map<String, String> COMMENTS = getCommentsFromDescriptorFile();
+
+  private DescriptorSet() {
+  }
+
+  private static Map<String, String> getCommentsFromDescriptorFile() {
+
+    try {
+      InputStream is = DescriptorSet.class.getClassLoader().getResourceAsStream(DEFAULT_DESCRIPTOR_SET_FILE_LOCATION);
+      DescriptorProtos.FileDescriptorSet descriptors = DescriptorProtos.FileDescriptorSet.parseFrom(is);
+      return descriptors
+          .getFileList()
+          .stream()
+          .flatMap(fileDescriptorProto -> parseDescriptorFile(fileDescriptorProto)
+              .entrySet()
+              .stream()
+          )
+          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (entry, value) -> entry));
+    } catch (IOException ignored) {
+    }
+    return Collections.emptyMap();
+  }
+
+  private static Map<String, String> parseDescriptorFile(DescriptorProtos.FileDescriptorProto descriptor) {
+    return descriptor
+        .getSourceCodeInfo()
+        .getLocationList()
+        .stream()
+        .filter(location -> !(location.getLeadingComments().isEmpty() && location.getTrailingComments().isEmpty()))
+        .map(location -> getFullName(descriptor, location.getPathList())
+            .map(fullName -> new AbstractMap.SimpleImmutableEntry<>(fullName, constructComment(location)))
+        )
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  private static String constructComment(DescriptorProtos.SourceCodeInfo.Location location) {
+    String trailingComment = location.getTrailingComments().trim();
+    return (location.getLeadingComments().trim()
+        + (!trailingComment.isEmpty() ? (". " + trailingComment) : "")
+    ).replaceAll("^[*\\\\/.]*\\s*", "");
+  }
+
+  /**
+   * Iterate through a component's path inside a protobufer descriptor.
+   * The path is a tuple of component type and a relative position
+   * For example:
+   * [4, 1, 3, 2, 2, 1] or [MESSAGE_TYPE_FIELD_NUMBER, 1, NESTED_TYPE_FIELD_NUMBER, 2, FIELD_FIELD_NUMBER, 1]
+   * is representing the second field of the third nested message in the second message in the file
+   * @see DescriptorProtos.SourceCodeInfoOrBuilder for more info
+   *
+   * @param descriptor proto file descriptor
+   * @param path       path of the element
+   * @return full element's path as a string
+   */
+  private static Optional<String> getFullName(DescriptorProtos.FileDescriptorProto descriptor, List<Integer> path) {
+    String fullName = descriptor.getPackage();
+    switch (path.get(0)) {
+      case DescriptorProtos.FileDescriptorProto.ENUM_TYPE_FIELD_NUMBER:
+        DescriptorProtos.EnumDescriptorProto enumDescriptor = descriptor.getEnumType(path.get(1));
+        return Optional.of(appendEnum(enumDescriptor, path, fullName));
+      case DescriptorProtos.FileDescriptorProto.MESSAGE_TYPE_FIELD_NUMBER:
+        DescriptorProtos.DescriptorProto message = descriptor.getMessageType(path.get(1));
+        return appendMessage(message, path, fullName);
+      case DescriptorProtos.FileDescriptorProto.SERVICE_FIELD_NUMBER:
+        DescriptorProtos.ServiceDescriptorProto serviceDescriptor = descriptor.getService(path.get(1));
+        fullName += appendNameComponent(serviceDescriptor.getName());
+        if (path.size() > 2) {
+          fullName += appendNameComponent(serviceDescriptor.getMethod(path.get(3)).getName());
+        }
+        return Optional.of(fullName);
+      default:
+        return Optional.empty();
+    }
+  }
+
+  private static Optional<String> append(
+      DescriptorProtos.DescriptorProto messageDescriptor, List<Integer> path, String fullName) {
+    switch (path.get(0)) {
+      case DescriptorProtos.DescriptorProto.NESTED_TYPE_FIELD_NUMBER:
+        DescriptorProtos.DescriptorProto nestedMessage = messageDescriptor.getNestedType(path.get(1));
+        return appendMessage(nestedMessage, path, fullName);
+      case DescriptorProtos.DescriptorProto.ENUM_TYPE_FIELD_NUMBER:
+        DescriptorProtos.EnumDescriptorProto enumDescriptor = messageDescriptor.getEnumType(path.get(1));
+        return Optional.of(appendEnum(enumDescriptor, path, fullName));
+      case DescriptorProtos.DescriptorProto.FIELD_FIELD_NUMBER:
+        DescriptorProtos.FieldDescriptorProto fieldDescriptor = messageDescriptor.getField(path.get(1));
+        return Optional.of(fullName + appendNameComponent(fieldDescriptor.getName()));
+      default:
+        return Optional.empty();
+    }
+  }
+
+  private static Optional<String> appendMessage(
+      DescriptorProtos.DescriptorProto message, List<Integer> path, String fullName) {
+    fullName += appendNameComponent(message.getName());
+    return path.size() > 2 ?
+        append(message, path.subList(2, path.size()), fullName)
+        : Optional.of(fullName);
+  }
+
+  private static String appendEnum(
+      DescriptorProtos.EnumDescriptorProto enumDescriptor, List<Integer> path, String fullName) {
+    fullName += appendNameComponent(enumDescriptor.getName());
+    if (path.size() > 2) {
+      fullName += appendNameComponent(enumDescriptor.getValue(path.get(3)).getName());
+    }
+    return fullName;
+  }
+
+  private static String appendNameComponent(String component) {
+    return "." + component;
+  }
+
+}

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/GqlInputConverter.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/GqlInputConverter.java
@@ -114,8 +114,11 @@ final class GqlInputConverter {
         inputBuilder.type((GraphQLInputType) fieldType);
       }
 
+      inputBuilder.description(DescriptorSet.COMMENTS.get(field.getFullName()));
+
       builder.field(inputBuilder.build());
     }
+    builder.description(DescriptorSet.COMMENTS.get(descriptor.getFullName()));
     return builder.build();
   }
 

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/Mutation.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/Mutation.java
@@ -22,4 +22,6 @@ import java.lang.annotation.RetentionPolicy;
 public @interface Mutation {
   /** Name of the Mutation, only used when annotating a method. */
   String value() default "";
+  /** Full service name (including package) to be able to find appropriate metadata in generated descriptor set. */
+  String fullName() default "";
 }

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/ProtoToGql.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/ProtoToGql.java
@@ -155,16 +155,7 @@ final class ProtoToGql {
               .dataFetcher(
                   new ProtoDataFetcher(convertedFieldName))
               .name(convertedFieldName);
-      if (fieldDescriptor.getFile().toProto().getSourceCodeInfo().getLocationCount()
-          > fieldDescriptor.getIndex()) {
-        builder.description(
-            fieldDescriptor
-                .getFile()
-                .toProto()
-                .getSourceCodeInfo()
-                .getLocation(fieldDescriptor.getIndex())
-                .getLeadingComments());
-      }
+      builder.description(DescriptorSet.COMMENTS.get(fieldDescriptor.getFullName()));
       if (fieldDescriptor.getOptions().hasDeprecated()
           && fieldDescriptor.getOptions().getDeprecated()) {
         builder.deprecate("deprecated in proto");
@@ -246,6 +237,7 @@ final class ProtoToGql {
 
     return GraphQLObjectType.newObject()
         .name(getReferenceName(descriptor))
+        .description(DescriptorSet.COMMENTS.get(descriptor.getFullName()))
         .fields(graphQLFieldDefinitions.isEmpty() ? STATIC_FIELD : graphQLFieldDefinitions)
         .build();
   }
@@ -253,7 +245,8 @@ final class ProtoToGql {
   static GraphQLEnumType convert(EnumDescriptor descriptor) {
     GraphQLEnumType.Builder builder = GraphQLEnumType.newEnum().name(getReferenceName(descriptor));
     for (EnumValueDescriptor value : descriptor.getValues()) {
-      builder.value(value.getName());
+      builder.value(value.getName(), value.getName(), DescriptorSet.COMMENTS.get(value.getFullName()),
+          value.getOptions().getDeprecated() ? "deprecated in proto" : null);
     }
     return builder.build();
   }

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/Query.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/Query.java
@@ -23,4 +23,7 @@ public @interface Query {
 
   /** Name of the Query, only used when annotating a method. */
   String value() default "";
+  /** Full service name (including package) to be able to find appropriate metadata in generated descriptor set. */
+  String fullName() default "";
+
 }

--- a/rejoiner/src/test/java/com/google/api/graphql/rejoiner/ProtoRegistryTest.java
+++ b/rejoiner/src/test/java/com/google/api/graphql/rejoiner/ProtoRegistryTest.java
@@ -38,9 +38,12 @@ public final class ProtoRegistryTest {
             "javatests_com_google_api_graphql_rejoiner_proto_Proto2",
             "javatests_com_google_api_graphql_rejoiner_proto_Proto1_InnerProto",
             "javatests_com_google_api_graphql_rejoiner_proto_Proto2_TestEnum",
+            "javatests_com_google_api_graphql_rejoiner_proto_Proto2_NestedProto",
+            "javatests_com_google_api_graphql_rejoiner_proto_TestEnumWithComments",
             "Input_javatests_com_google_api_graphql_rejoiner_proto_Proto1",
             "Input_javatests_com_google_api_graphql_rejoiner_proto_Proto2",
-            "Input_javatests_com_google_api_graphql_rejoiner_proto_Proto1_InnerProto");
+            "Input_javatests_com_google_api_graphql_rejoiner_proto_Proto1_InnerProto",
+            "Input_javatests_com_google_api_graphql_rejoiner_proto_Proto2_NestedProto");
   }
 
   private static final Function<GraphQLType, String> GET_NAME = type -> type.getName();

--- a/rejoiner/src/test/java/com/google/api/graphql/rejoiner/ProtoToGqlTest.java
+++ b/rejoiner/src/test/java/com/google/api/graphql/rejoiner/ProtoToGqlTest.java
@@ -95,11 +95,24 @@ public final class ProtoToGqlTest {
     assertThat(testProtoNameGraphQLFieldDefinition).isNotNull();
     assertThat(testProtoNameGraphQLFieldDefinition.getDescription().equals("Some trailing comment")).isTrue();
 
+    GraphQLEnumType nestedEnumType = ProtoToGql.convert(TestEnum.getDescriptor());
 
-    GraphQLEnumType enumType = ProtoToGql.convert(TestEnum.getDescriptor());
-
-    GraphQLEnumValueDefinition graphQLFieldDefinition = enumType.getValue("UNKNOWN");
+    GraphQLEnumValueDefinition graphQLFieldDefinition = nestedEnumType.getValue("UNKNOWN");
     assertThat(graphQLFieldDefinition.getDescription().equals("Some trailing comment")).isTrue();
+
+    GraphQLObjectType nestedMessageType = ProtoToGql.convert(Proto2.NestedProto.getDescriptor(), null);
+
+    assertThat(nestedMessageType.getDescription().equals("Nested type comment")).isTrue();
+
+    GraphQLFieldDefinition nestedFieldGraphQLFieldDefinition = nestedMessageType.getFieldDefinition("nestedId");
+    assertThat(nestedFieldGraphQLFieldDefinition).isNotNull();
+    assertThat(nestedFieldGraphQLFieldDefinition.getDescription().equals("Some nested id")).isTrue();
+
+    GraphQLEnumType enumType = ProtoToGql.convert(TestProto.TestEnumWithComments.getDescriptor());
+
+    graphQLFieldDefinition = enumType.getValue("FOO");
+    assertThat(graphQLFieldDefinition.getDescription().equals("Some trailing comment")).isTrue();
+
   }
 
 }

--- a/rejoiner/src/test/java/com/google/api/graphql/rejoiner/ProtoToGqlTest.java
+++ b/rejoiner/src/test/java/com/google/api/graphql/rejoiner/ProtoToGqlTest.java
@@ -22,6 +22,7 @@ import com.google.api.graphql.rejoiner.TestProto.Proto2;
 import com.google.api.graphql.rejoiner.TestProto.Proto2.TestEnum;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLEnumValueDefinition;
+import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -77,4 +78,28 @@ public final class ProtoToGqlTest {
     assertThat(result.getFieldDefinition("intField")).isNotNull();
     assertThat(result.getFieldDefinition("camelCaseName")).isNotNull();
   }
+
+  @Test
+  public void checkComments() {
+    GraphQLObjectType result = ProtoToGql.convert(Proto1.getDescriptor(), null);
+
+    GraphQLFieldDefinition intFieldGraphQLFieldDefinition = result.getFieldDefinition("intField");
+    assertThat(intFieldGraphQLFieldDefinition).isNotNull();
+    assertThat(intFieldGraphQLFieldDefinition.getDescription().equals("Some leading comment. Some trailing comment")).isTrue();
+
+    GraphQLFieldDefinition camelCaseNameGraphQLFieldDefinition = result.getFieldDefinition("camelCaseName");
+    assertThat(camelCaseNameGraphQLFieldDefinition).isNotNull();
+    assertThat(camelCaseNameGraphQLFieldDefinition.getDescription().equals("Some leading comment")).isTrue();
+
+    GraphQLFieldDefinition testProtoNameGraphQLFieldDefinition = result.getFieldDefinition("testProto");
+    assertThat(testProtoNameGraphQLFieldDefinition).isNotNull();
+    assertThat(testProtoNameGraphQLFieldDefinition.getDescription().equals("Some trailing comment")).isTrue();
+
+
+    GraphQLEnumType enumType = ProtoToGql.convert(TestEnum.getDescriptor());
+
+    GraphQLEnumValueDefinition graphQLFieldDefinition = enumType.getValue("UNKNOWN");
+    assertThat(graphQLFieldDefinition.getDescription().equals("Some trailing comment")).isTrue();
+  }
+
 }

--- a/rejoiner/src/test/proto/test_proto.proto
+++ b/rejoiner/src/test/proto/test_proto.proto
@@ -20,9 +20,11 @@ option java_package = "com.google.api.graphql.rejoiner";
 
 message Proto1 {
   string id = 1;
-  int64 int_field = 2;
-  Proto2 test_proto = 3;
+  //Some leading comment
+  int64 int_field = 2;//Some trailing comment
+  Proto2 test_proto = 3;//Some trailing comment
   InnerProto test_inner_proto = 4;
+  //Some leading comment
   int64 camelCaseName = 5;
 
   message InnerProto {
@@ -34,8 +36,9 @@ message Proto2 {
   string inner_id = 1;
   repeated TestEnum enums = 2;
 
+  //Enum comment
   enum TestEnum {
-    UNKNOWN = 0;
+    UNKNOWN = 0; //Some trailing comment
     FOO = 1;
     BAR = 2;
   }

--- a/rejoiner/src/test/proto/test_proto.proto
+++ b/rejoiner/src/test/proto/test_proto.proto
@@ -32,11 +32,22 @@ message Proto1 {
   }
 }
 
+//Enum comment
+enum TestEnumWithComments {
+  FOO = 0; //Some trailing comment
+  BAR = 1;
+}
+
 message Proto2 {
   string inner_id = 1;
   repeated TestEnum enums = 2;
 
-  //Enum comment
+  // Nested type comment
+  message NestedProto {
+    string nested_id = 1; //Some nested id
+  }
+
+    //Enum comment
   enum TestEnum {
     UNKNOWN = 0; //Some trailing comment
     FOO = 1;


### PR DESCRIPTION
I'm proposing to use standard protobuf description set file as a source of comments in order to propagate comments from proto to GraphQL schema

The proto description set file could be generated by protobuf plugin:

Maven:
```
   <plugin>
       <groupId>org.xolstice.maven.plugins</groupId>
       <artifactId>protobuf-maven-plugin</artifactId>
       <version>0.5.1</version>
       <configuration>
         <writeDescriptorSet>true</writeDescriptorSet>
         <descriptorSetFileName>descriptor_set.desc</descriptorSetFileName>
         <descriptorSetOutputDirectory>${build.directory}/test-classes/META-INF/proto</descriptorSetOutputDirectory>
         <includeSourceInfoInDescriptorSet>true</includeSourceInfoInDescriptorSet>
         <includeDependenciesInDescriptorSet>true</includeDependenciesInDescriptorSet>
       </configuration>
   .....
    </plugin>
```
Grails:
```
protobuf {
    protoc { artifact = "com.google.protobuf:protoc:${protocVersion}" }
    plugins {
        grpc { artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}" }
    }
    generateProtoTasks {
        ofSourceSet('main').each{task ->
            task.generateDescriptorSet = true
            task.descriptorSetOptions.includeImports = true
            task.descriptorSetOptions.includeSourceInfo = true
            task.descriptorSetOptions.path = "${buildDir}/resources/main/META-INF/proto/descriptor_set.desc"
            task.plugins {
                grpc {}
            }
        }
    }
}
```
The generated protofile description file must be named as `descriptor_set.desc` and located in `META-INF/proto` of the final jar file