### PR TITLE
Schema module refactor

### DIFF
--- a/rejoiner/pom.xml
+++ b/rejoiner/pom.xml
@@ -16,7 +16,9 @@
  limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<!-- To check for updates: mvn versions:display-dependency-updates -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -79,7 +81,7 @@
     <dependency>
       <groupId>com.graphql-java</groupId>
       <artifactId>graphql-java</artifactId>
-      <version>2018-11-28T08-13-20-3ada93e</version>
+      <version>2019-04-09T05-29-53-bd9240c</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -159,9 +161,9 @@
 
   </dependencies>
   <build>
-  <plugins>
-    <plugin>
-      <groupId>org.apache.maven.plugins</groupId>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.7.0</version>
         <configuration>
@@ -186,120 +188,121 @@
             <version>2.3.1</version>
           </dependency>
         </dependencies>
-    </plugin>
-    <plugin>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-source-plugin</artifactId>
-      <version>2.2.1</version>
-      <executions>
-        <execution>
-          <id>attach-sources</id>
-          <goals>
-            <goal>jar-no-fork</goal>
-          </goals>
-        </execution>
-      </executions>
-    </plugin>
-    <plugin>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-javadoc-plugin</artifactId>
-      <version>2.9.1</version>
-      <executions>
-        <execution>
-          <id>attach-javadocs</id>
-          <goals>
-            <goal>jar</goal>
-          </goals>
-        </execution>
-      </executions>
-      <configuration>
-        <additionalparam>-Xdoclint:none</additionalparam>
-      </configuration>
-    </plugin>
-    <plugin>
-     <groupId>org.apache.maven.plugins</groupId>
-     <artifactId>maven-gpg-plugin</artifactId>
-     <version>1.5</version>
-     <executions>
-       <execution>
-         <id>sign-artifacts</id>
-         <phase>verify</phase>
-         <goals>
-           <goal>sign</goal>
-         </goals>
-       </execution>
-     </executions>
-   </plugin>
-    <plugin>
-      <groupId>org.sonatype.plugins</groupId>
-      <artifactId>nexus-staging-maven-plugin</artifactId>
-      <version>1.6.7</version>
-      <extensions>true</extensions>
-      <configuration>
-         <serverId>ossrh</serverId>
-         <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-         <autoReleaseAfterClose>true</autoReleaseAfterClose>
-      </configuration>
-    </plugin>
-    <plugin>
-       <groupId>org.xolstice.maven.plugins</groupId>
-       <artifactId>protobuf-maven-plugin</artifactId>
-       <version>0.5.1</version>
-       <configuration>
-         <protocExecutable>/usr/local/bin/protoc</protocExecutable>
-         <writeDescriptorSet>true</writeDescriptorSet>
-         <descriptorSetFileName>descriptor_set.desc</descriptorSetFileName>
-         <descriptorSetOutputDirectory>${build.directory}/test-classes/META-INF/proto</descriptorSetOutputDirectory>
-         <includeSourceInfoInDescriptorSet>true</includeSourceInfoInDescriptorSet>
-         <includeDependenciesInDescriptorSet>true</includeDependenciesInDescriptorSet>
-       </configuration>
-       <executions>
-         <execution>
-           <goals>
-             <goal>compile</goal>
-             <goal>test-compile</goal>
-           </goals>
-         </execution>
-       </executions>
-    </plugin>
-    <plugin>
-      <groupId>org.jacoco</groupId>
-      <artifactId>jacoco-maven-plugin</artifactId>
-      <version>0.8.2</version>
-      <configuration>
-        <excludes>
-          <exclude>**/*AutoValue_*</exclude>
-          <exclude>**/generated-sources/**/*</exclude>
-        </excludes>
-      </configuration>
-      <executions>
-        <execution>
-          <id>prepare-agent</id>
-          <goals>
-            <goal>prepare-agent</goal>
-          </goals>
-        </execution>
-        <execution>
-          <id>report</id>
-          <phase>prepare-package</phase>
-          <goals>
-            <goal>report</goal>
-          </goals>
-        </execution>
-        <execution>
-          <id>post-unit-test</id>
-          <phase>test</phase>
-          <goals>
-            <goal>report</goal>
-          </goals>
-        </execution>
-      </executions>
-    </plugin>
-    <plugin>
-      <groupId>org.eluder.coveralls</groupId>
-      <artifactId>coveralls-maven-plugin</artifactId>
-      <version>4.3.0</version>
-    </plugin>
-  </plugins>
-</build>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9.1</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <additionalparam>-Xdoclint:none</additionalparam>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.5</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.7</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>0.5.1</version>
+        <configuration>
+          <protocExecutable>/usr/local/bin/protoc</protocExecutable>
+          <writeDescriptorSet>true</writeDescriptorSet>
+          <descriptorSetFileName>descriptor_set.desc</descriptorSetFileName>
+          <descriptorSetOutputDirectory>${build.directory}/test-classes/META-INF/proto
+          </descriptorSetOutputDirectory>
+          <includeSourceInfoInDescriptorSet>true</includeSourceInfoInDescriptorSet>
+          <includeDependenciesInDescriptorSet>true</includeDependenciesInDescriptorSet>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.2</version>
+        <configuration>
+          <excludes>
+            <exclude>**/*AutoValue_*</exclude>
+            <exclude>**/generated-sources/**/*</exclude>
+          </excludes>
+        </configuration>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>post-unit-test</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.eluder.coveralls</groupId>
+        <artifactId>coveralls-maven-plugin</artifactId>
+        <version>4.3.0</version>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/rejoiner/src/main/java/com/google/api/graphql/execution/ExecutionResultToProtoAsync.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/execution/ExecutionResultToProtoAsync.java
@@ -20,10 +20,9 @@ import com.google.api.graphql.grpc.QueryResponseToProto;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Message;
-import graphql.ExecutionResult;
 import graphql.ErrorType;
+import graphql.ExecutionResult;
 import graphql.GraphQLError;
-
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 

--- a/rejoiner/src/main/java/com/google/api/graphql/execution/GuavaListenableFutureSupport.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/execution/GuavaListenableFutureSupport.java
@@ -81,5 +81,4 @@ public final class GuavaListenableFutureSupport {
       }
     };
   }
-
 }

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/Annotations.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/Annotations.java
@@ -23,6 +23,10 @@ final class Annotations {
 
   private Annotations() {}
 
+
+  @Retention(RetentionPolicy.RUNTIME)
+  @Qualifier
+  @interface SchemaBundles {}
   @Retention(RetentionPolicy.RUNTIME)
   @Qualifier
   @interface Mutations {}

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/Annotations.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/Annotations.java
@@ -23,23 +23,7 @@ final class Annotations {
 
   private Annotations() {}
 
-
   @Retention(RetentionPolicy.RUNTIME)
   @Qualifier
   @interface SchemaBundles {}
-  @Retention(RetentionPolicy.RUNTIME)
-  @Qualifier
-  @interface Mutations {}
-
-  @Retention(RetentionPolicy.RUNTIME)
-  @Qualifier
-  @interface Queries {}
-
-  @Retention(RetentionPolicy.RUNTIME)
-  @Qualifier
-  @interface GraphModifications {}
-
-  @Retention(RetentionPolicy.RUNTIME)
-  @Qualifier
-  @interface ExtraTypes {}
 }

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/DescriptorSet.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/DescriptorSet.java
@@ -16,7 +16,6 @@ package com.google.api.graphql.rejoiner;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.DescriptorProtos;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.AbstractMap;
@@ -86,9 +85,8 @@ final class DescriptorSet {
   /**
    * Iterate through a component's path inside a proto descriptor.
    *
-   * <p>
-   * The path is a tuple of component type and a relative position For example: [4, 1, 3, 2, 2, 1] or
-   * [MESSAGE_TYPE_FIELD_NUMBER, 1, NESTED_TYPE_FIELD_NUMBER, 2, FIELD_FIELD_NUMBER, 1] is
+   * <p>The path is a tuple of component type and a relative position For example: [4, 1, 3, 2, 2,
+   * 1] or [MESSAGE_TYPE_FIELD_NUMBER, 1, NESTED_TYPE_FIELD_NUMBER, 2, FIELD_FIELD_NUMBER, 1] is
    * representing the second field of the third nested message in the second message in the file
    *
    * @see DescriptorProtos.SourceCodeInfoOrBuilder for more info

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/FieldDefinition.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/FieldDefinition.java
@@ -1,0 +1,24 @@
+package com.google.api.graphql.rejoiner;
+
+import com.google.auto.value.AutoValue;
+import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLFieldDefinition;
+
+/** A GraphQL field definition with it's data fetcher. */
+@AutoValue
+public abstract class FieldDefinition<T> {
+  abstract String parentTypeName();
+
+  abstract GraphQLFieldDefinition field();
+
+  abstract DataFetcher<T> dataFetcher();
+
+  static <T> FieldDefinition create(
+      String parentTypeName, GraphQLFieldDefinition field, DataFetcher<T> dataFetcher) {
+    return new AutoValue_FieldDefinition(parentTypeName, field, dataFetcher);
+  }
+
+  String fieldName() {
+    return field().getName();
+  }
+}

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/GqlInputConverter.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/GqlInputConverter.java
@@ -15,6 +15,7 @@
 package com.google.api.graphql.rejoiner;
 
 import static graphql.Scalars.GraphQLString;
+
 import com.google.common.base.CaseFormat;
 import com.google.common.base.Converter;
 import com.google.common.collect.BiMap;

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/GrpcSchemaModule.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/GrpcSchemaModule.java
@@ -9,7 +9,6 @@ import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLOutputType;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/Mutation.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/Mutation.java
@@ -22,6 +22,9 @@ import java.lang.annotation.RetentionPolicy;
 public @interface Mutation {
   /** Name of the Mutation, only used when annotating a method. */
   String value() default "";
-  /** Full service name (including package) to be able to find appropriate metadata in generated descriptor set. */
+  /**
+   * Full service name (including package) to be able to find appropriate metadata in generated
+   * descriptor set.
+   */
   String fullName() default "";
 }

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/ProtoRegistry.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/ProtoRegistry.java
@@ -110,7 +110,7 @@ final class ProtoRegistry {
       return this;
     }
 
-    Builder add(Set<TypeModification> modifications) {
+    Builder add(Collection<TypeModification> modifications) {
       typeModifications.addAll(modifications);
       return this;
     }

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/ProtoToGql.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/ProtoToGql.java
@@ -119,7 +119,10 @@ final class ProtoToGql {
             return null;
           }
           Map<?, ?> map = (Map<?, ?>) mapValue;
-          return map.entrySet().stream().map(entry -> ImmutableMap.of("key", entry.getKey(), "value", entry.getValue())).collect(toImmutableList());
+          return map.entrySet()
+              .stream()
+              .map(entry -> ImmutableMap.of("key", entry.getKey(), "value", entry.getValue()))
+              .collect(toImmutableList());
         }
         if (type instanceof GraphQLEnumType) {
           Object o = call(source, "get" + LOWER_CAMEL_TO_UPPER.convert(name));
@@ -146,12 +149,12 @@ final class ProtoToGql {
     @Override
     public GraphQLFieldDefinition apply(FieldDescriptor fieldDescriptor) {
       String fieldName = fieldDescriptor.getName();
-      String convertedFieldName = fieldName.contains("_") ? UNDERSCORE_TO_CAMEL.convert(fieldName) : fieldName;
+      String convertedFieldName =
+          fieldName.contains("_") ? UNDERSCORE_TO_CAMEL.convert(fieldName) : fieldName;
       GraphQLFieldDefinition.Builder builder =
           GraphQLFieldDefinition.newFieldDefinition()
               .type(convertType(fieldDescriptor))
-              .dataFetcher(
-                  new ProtoDataFetcher(convertedFieldName))
+              .dataFetcher(new ProtoDataFetcher(convertedFieldName))
               .name(fieldDescriptor.getJsonName());
       builder.description(DescriptorSet.COMMENTS.get(fieldDescriptor.getFullName()));
       if (fieldDescriptor.getOptions().hasDeprecated()
@@ -211,27 +214,27 @@ final class ProtoToGql {
                         .build())
             .findFirst();
 
-    if (relayId.isPresent()) {
-      return GraphQLObjectType.newObject()
-          .name(getReferenceName(descriptor))
-          .withInterface(nodeInterface)
-          .field(relayId.get())
-          .fields(
-              graphQLFieldDefinitions
-                  .stream()
-                  .map(
-                      field ->
-                          field.getName().equals("id")
-                              ? GraphQLFieldDefinition.newFieldDefinition()
-                                  .name("rawId")
-                                  .description(field.getDescription())
-                                  .type(field.getType())
-                                  .dataFetcher(field.getDataFetcher())
-                                  .build()
-                              : field)
-                  .collect(ImmutableList.toImmutableList()))
-          .build();
-    }
+    //   if (relayId.isPresent()) {
+    //      return GraphQLObjectType.newObject()
+    //          .name(getReferenceName(descriptor))
+    //          .withInterface(nodeInterface)
+    //          .field(relayId.get())
+    //          .fields(
+    //              graphQLFieldDefinitions
+    //                  .stream()
+    //                  .map(
+    //                      field ->
+    //                          field.getName().equals("id")
+    //                              ? GraphQLFieldDefinition.newFieldDefinition()
+    //                                  .name("rawId")
+    //                                  .description(field.getDescription())
+    //                                  .type(field.getType())
+    //                                  .dataFetcher(field.getDataFetcher())
+    //                                  .build()
+    //                              : field)
+    //                  .collect(ImmutableList.toImmutableList()))
+    //          .build();
+    //    }
 
     return GraphQLObjectType.newObject()
         .name(getReferenceName(descriptor))
@@ -243,7 +246,10 @@ final class ProtoToGql {
   static GraphQLEnumType convert(EnumDescriptor descriptor) {
     GraphQLEnumType.Builder builder = GraphQLEnumType.newEnum().name(getReferenceName(descriptor));
     for (EnumValueDescriptor value : descriptor.getValues()) {
-      builder.value(value.getName(), value.getName(), DescriptorSet.COMMENTS.get(value.getFullName()),
+      builder.value(
+          value.getName(),
+          value.getName(),
+          DescriptorSet.COMMENTS.get(value.getFullName()),
           value.getOptions().getDeprecated() ? "deprecated in proto" : null);
     }
     return builder.build();

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/Query.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/Query.java
@@ -23,7 +23,9 @@ public @interface Query {
 
   /** Name of the Query, only used when annotating a method. */
   String value() default "";
-  /** Full service name (including package) to be able to find appropriate metadata in generated descriptor set. */
+  /**
+   * Full service name (including package) to be able to find appropriate metadata in generated
+   * descriptor set.
+   */
   String fullName() default "";
-
 }

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaBundle.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaBundle.java
@@ -1,24 +1,24 @@
 package com.google.api.graphql.rejoiner;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Descriptors;
 import graphql.schema.GraphQLFieldDefinition;
 import java.util.Collection;
-import javax.inject.Provider;
 
 @AutoValue
 public abstract class SchemaBundle {
 
-  public abstract ImmutableSet<GraphQLFieldDefinition> queryFields();
+  public abstract ImmutableList<GraphQLFieldDefinition> queryFields();
 
-  public abstract ImmutableSet<GraphQLFieldDefinition> mutationFields();
+  public abstract ImmutableList<GraphQLFieldDefinition> mutationFields();
 
-  public abstract ImmutableSet<TypeModification> modifications();
+  public abstract ImmutableList<TypeModification> modifications();
 
   public abstract ImmutableSet<Descriptors.FileDescriptor> fileDescriptors();
 
-  public abstract ImmutableSet<NodeDataFetcher> nodeDataFetchers();
+  public abstract ImmutableList<NodeDataFetcher> nodeDataFetchers();
 
   public static Builder builder() {
     return new AutoValue_SchemaBundle.Builder();
@@ -37,25 +37,17 @@ public abstract class SchemaBundle {
     return builder.build();
   }
 
-  public static SchemaBundle combineProviders(Collection<Provider<SchemaBundle>> schemaBundles) {
-    return combine(
-        schemaBundles
-            .stream()
-            .map(schemaBundleProvider -> schemaBundleProvider.get())
-            .collect(ImmutableSet.toImmutableSet()));
-  }
-
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract ImmutableSet.Builder<GraphQLFieldDefinition> queryFieldsBuilder();
+    public abstract ImmutableList.Builder<GraphQLFieldDefinition> queryFieldsBuilder();
 
-    public abstract ImmutableSet.Builder<GraphQLFieldDefinition> mutationFieldsBuilder();
+    public abstract ImmutableList.Builder<GraphQLFieldDefinition> mutationFieldsBuilder();
 
-    public abstract ImmutableSet.Builder<TypeModification> modificationsBuilder();
+    public abstract ImmutableList.Builder<TypeModification> modificationsBuilder();
 
     public abstract ImmutableSet.Builder<Descriptors.FileDescriptor> fileDescriptorsBuilder();
 
-    public abstract ImmutableSet.Builder<NodeDataFetcher> nodeDataFetchersBuilder();
+    public abstract ImmutableList.Builder<NodeDataFetcher> nodeDataFetchersBuilder();
 
     public abstract SchemaBundle build();
   }

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaBundle.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaBundle.java
@@ -1,0 +1,64 @@
+package com.google.api.graphql.rejoiner;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+import com.google.protobuf.Descriptors;
+import graphql.schema.GraphQLFieldDefinition;
+
+import javax.inject.Provider;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+@AutoValue
+public abstract class SchemaBundle {
+
+  public abstract ImmutableSet<GraphQLFieldDefinition> queryFields();
+
+  public abstract ImmutableSet<GraphQLFieldDefinition> mutationFields();
+
+  public abstract ImmutableSet<TypeModification> modifications();
+
+  public abstract ImmutableSet<Descriptors.FileDescriptor> fileDescriptors();
+
+  public abstract ImmutableSet<NodeDataFetcher> nodeDataFetchers();
+
+  public static Builder builder() {
+    return new AutoValue_SchemaBundle.Builder();
+  }
+
+  public static SchemaBundle combine(Collection<SchemaBundle> schemaBundles) {
+    Builder builder = SchemaBundle.builder();
+    schemaBundles.forEach(
+        schemaBundle -> {
+          builder.queryFieldsBuilder().addAll(schemaBundle.queryFields());
+          builder.mutationFieldsBuilder().addAll(schemaBundle.mutationFields());
+          builder.modificationsBuilder().addAll(schemaBundle.modifications());
+          builder.fileDescriptorsBuilder().addAll(schemaBundle.fileDescriptors());
+          builder.nodeDataFetchersBuilder().addAll(schemaBundle.nodeDataFetchers());
+        });
+    return builder.build();
+  }
+
+  public static SchemaBundle combineProviders(Collection<Provider<SchemaBundle>> schemaBundles) {
+    return combine(
+        schemaBundles
+            .stream()
+            .map(schemaBundleProvider -> schemaBundleProvider.get())
+            .collect(ImmutableSet.toImmutableSet()));
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract ImmutableSet.Builder<GraphQLFieldDefinition> queryFieldsBuilder();
+
+    public abstract ImmutableSet.Builder<GraphQLFieldDefinition> mutationFieldsBuilder();
+
+    public abstract ImmutableSet.Builder<TypeModification> modificationsBuilder();
+
+    public abstract ImmutableSet.Builder<Descriptors.FileDescriptor> fileDescriptorsBuilder();
+
+    public abstract ImmutableSet.Builder<NodeDataFetcher> nodeDataFetchersBuilder();
+
+    public abstract SchemaBundle build();
+  }
+}

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaBundle.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaBundle.java
@@ -4,10 +4,8 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Descriptors;
 import graphql.schema.GraphQLFieldDefinition;
-
-import javax.inject.Provider;
 import java.util.Collection;
-import java.util.stream.Collectors;
+import javax.inject.Provider;
 
 @AutoValue
 public abstract class SchemaBundle {

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaModule.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaModule.java
@@ -30,7 +30,16 @@ import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FileDescriptor;
 import com.google.protobuf.Message;
 import graphql.Scalars;
-import graphql.schema.*;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLScalarType;
+import graphql.schema.GraphQLTypeReference;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaModule.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaModule.java
@@ -40,7 +40,6 @@ import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLTypeReference;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaProviderModule.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaProviderModule.java
@@ -16,13 +16,10 @@ package com.google.api.graphql.rejoiner;
 
 import static graphql.schema.GraphQLObjectType.newObject;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
-import com.google.protobuf.Descriptors.FileDescriptor;
 import graphql.relay.Relay;
-import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import java.util.Map;
@@ -36,16 +33,17 @@ import javax.inject.Provider;
 public final class SchemaProviderModule extends AbstractModule {
 
   static class SchemaImpl implements Provider<GraphQLSchema> {
-    private final ImmutableSet<Provider<SchemaBundle>> schemaBundleProviders;
+
+    private final Provider<Set<SchemaBundle>> schemaBundleProviders;
 
     @Inject
-    public SchemaImpl(@Annotations.SchemaBundles Set<Provider<SchemaBundle>> schemaBundles) {
-      this.schemaBundleProviders = ImmutableSet.copyOf(schemaBundles);
+    public SchemaImpl(@Annotations.SchemaBundles Provider<Set<SchemaBundle>> schemaBundles) {
+      this.schemaBundleProviders = schemaBundles;
     }
 
     @Override
     public GraphQLSchema get() {
-      SchemaBundle schemaBundle = SchemaBundle.combineProviders(schemaBundleProviders);
+      SchemaBundle schemaBundle = SchemaBundle.combine(schemaBundleProviders.get());
       Map<String, ? extends Function<String, Object>> nodeDataFetchers =
           schemaBundle
               .nodeDataFetchers()

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaProviderModule.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaProviderModule.java
@@ -16,7 +16,6 @@ package com.google.api.graphql.rejoiner;
 
 import static graphql.schema.GraphQLObjectType.newObject;
 
-import com.google.common.collect.Lists;
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
 import graphql.relay.Relay;
@@ -51,7 +50,7 @@ public final class SchemaProviderModule extends AbstractModule {
               .collect(Collectors.toMap(e -> e.getClassName(), Function.identity()));
 
       GraphQLObjectType.Builder queryType =
-          newObject().name("QueryType").fields(Lists.newArrayList(schemaBundle.queryFields()));
+          newObject().name("QueryType").fields(schemaBundle.queryFields());
 
       ProtoRegistry protoRegistry =
           ProtoRegistry.newBuilder()
@@ -83,10 +82,7 @@ public final class SchemaProviderModule extends AbstractModule {
         return GraphQLSchema.newSchema().query(queryType).build(protoRegistry.listTypes());
       }
       GraphQLObjectType mutationType =
-          newObject()
-              .name("MutationType")
-              .fields(Lists.newArrayList(schemaBundle.mutationFields()))
-              .build();
+          newObject().name("MutationType").fields(schemaBundle.mutationFields()).build();
       return GraphQLSchema.newSchema()
           .query(queryType)
           .mutation(mutationType)

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaProviderModule.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaProviderModule.java
@@ -16,6 +16,7 @@ package com.google.api.graphql.rejoiner;
 
 import static graphql.schema.GraphQLObjectType.newObject;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
@@ -35,38 +36,30 @@ import javax.inject.Provider;
 public final class SchemaProviderModule extends AbstractModule {
 
   static class SchemaImpl implements Provider<GraphQLSchema> {
-    private final Set<GraphQLFieldDefinition> queryFields;
-    private final Set<GraphQLFieldDefinition> mutationFields;
-    private final Set<TypeModification> modifications;
-    private final Set<FileDescriptor> fileDescriptors;
-    private final Set<NodeDataFetcher> nodeDataFetchers;
+    private final ImmutableSet<Provider<SchemaBundle>> schemaBundleProviders;
 
     @Inject
-    public SchemaImpl(
-        @Annotations.Queries Set<GraphQLFieldDefinition> queryFields,
-        @Annotations.Mutations Set<GraphQLFieldDefinition> mutationFields,
-        @Annotations.GraphModifications Set<TypeModification> modifications,
-        @Annotations.ExtraTypes Set<FileDescriptor> fileDescriptors,
-        @Annotations.Queries Set<NodeDataFetcher> nodeDataFetchers) {
-      this.queryFields = queryFields;
-      this.mutationFields = mutationFields;
-      this.modifications = modifications;
-      this.fileDescriptors = fileDescriptors;
-      this.nodeDataFetchers = nodeDataFetchers;
+    public SchemaImpl(@Annotations.SchemaBundles Set<Provider<SchemaBundle>> schemaBundles) {
+      this.schemaBundleProviders = ImmutableSet.copyOf(schemaBundles);
     }
 
     @Override
     public GraphQLSchema get() {
+      SchemaBundle schemaBundle = SchemaBundle.combineProviders(schemaBundleProviders);
       Map<String, ? extends Function<String, Object>> nodeDataFetchers =
-          this.nodeDataFetchers
+          schemaBundle
+              .nodeDataFetchers()
               .stream()
               .collect(Collectors.toMap(e -> e.getClassName(), Function.identity()));
 
       GraphQLObjectType.Builder queryType =
-          newObject().name("QueryType").fields(Lists.newArrayList(queryFields));
+          newObject().name("QueryType").fields(Lists.newArrayList(schemaBundle.queryFields()));
 
       ProtoRegistry protoRegistry =
-          ProtoRegistry.newBuilder().addAll(fileDescriptors).add(modifications).build();
+          ProtoRegistry.newBuilder()
+              .addAll(schemaBundle.fileDescriptors())
+              .add(schemaBundle.modifications())
+              .build();
 
       if (protoRegistry.hasRelayNode()) {
         queryType.field(
@@ -88,11 +81,14 @@ public final class SchemaProviderModule extends AbstractModule {
                     }));
       }
 
-      if (mutationFields.isEmpty()) {
+      if (schemaBundle.mutationFields().isEmpty()) {
         return GraphQLSchema.newSchema().query(queryType).build(protoRegistry.listTypes());
       }
       GraphQLObjectType mutationType =
-          newObject().name("MutationType").fields(Lists.newArrayList(mutationFields)).build();
+          newObject()
+              .name("MutationType")
+              .fields(Lists.newArrayList(schemaBundle.mutationFields()))
+              .build();
       return GraphQLSchema.newSchema()
           .query(queryType)
           .mutation(mutationType)
@@ -103,8 +99,8 @@ public final class SchemaProviderModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(GraphQLSchema.class)
-      .annotatedWith(Schema.class)
-      .toProvider(SchemaImpl.class)
-      .in(Singleton.class);
+        .annotatedWith(Schema.class)
+        .toProvider(SchemaImpl.class)
+        .in(Singleton.class);
   }
 }

--- a/rejoiner/src/test/java/com/google/api/graphql/grpc/SchemaToProtoTest.java
+++ b/rejoiner/src/test/java/com/google/api/graphql/grpc/SchemaToProtoTest.java
@@ -63,27 +63,22 @@ public final class SchemaToProtoTest {
                             .field(
                                 GraphQLFieldDefinition.newFieldDefinition()
                                     .name("string")
-                                    .staticValue(new Object())
                                     .type(Scalars.GraphQLString))
                             .field(
                                 GraphQLFieldDefinition.newFieldDefinition()
                                     .name("boolean")
-                                    .staticValue(new Object())
                                     .type(Scalars.GraphQLBoolean))
                             .field(
                                 GraphQLFieldDefinition.newFieldDefinition()
                                     .name("float")
-                                    .staticValue(new Object())
                                     .type(Scalars.GraphQLFloat))
                             .field(
                                 GraphQLFieldDefinition.newFieldDefinition()
                                     .name("int")
-                                    .staticValue(new Object())
                                     .type(Scalars.GraphQLInt))
                             .field(
                                 GraphQLFieldDefinition.newFieldDefinition()
                                     .name("long")
-                                    .staticValue(new Object())
                                     .type(Scalars.GraphQLLong)))
                     .build()))
         .isEqualTo(

--- a/rejoiner/src/test/java/com/google/api/graphql/rejoiner/ProtoToGqlTest.java
+++ b/rejoiner/src/test/java/com/google/api/graphql/rejoiner/ProtoToGqlTest.java
@@ -86,34 +86,43 @@ public final class ProtoToGqlTest {
 
     GraphQLFieldDefinition intFieldGraphQLFieldDefinition = result.getFieldDefinition("intField");
     assertThat(intFieldGraphQLFieldDefinition).isNotNull();
-    assertThat(intFieldGraphQLFieldDefinition.getDescription().equals("Some leading comment. Some trailing comment")).isTrue();
+    assertThat(
+            intFieldGraphQLFieldDefinition
+                .getDescription()
+                .equals("Some leading comment. Some trailing comment"))
+        .isTrue();
 
-    GraphQLFieldDefinition camelCaseNameGraphQLFieldDefinition = result.getFieldDefinition("camelCaseName");
+    GraphQLFieldDefinition camelCaseNameGraphQLFieldDefinition =
+        result.getFieldDefinition("camelCaseName");
     assertThat(camelCaseNameGraphQLFieldDefinition).isNotNull();
-    assertThat(camelCaseNameGraphQLFieldDefinition.getDescription().equals("Some leading comment")).isTrue();
+    assertThat(camelCaseNameGraphQLFieldDefinition.getDescription().equals("Some leading comment"))
+        .isTrue();
 
-    GraphQLFieldDefinition testProtoNameGraphQLFieldDefinition = result.getFieldDefinition("testProto");
+    GraphQLFieldDefinition testProtoNameGraphQLFieldDefinition =
+        result.getFieldDefinition("testProto");
     assertThat(testProtoNameGraphQLFieldDefinition).isNotNull();
-    assertThat(testProtoNameGraphQLFieldDefinition.getDescription().equals("Some trailing comment")).isTrue();
+    assertThat(testProtoNameGraphQLFieldDefinition.getDescription().equals("Some trailing comment"))
+        .isTrue();
 
     GraphQLEnumType nestedEnumType = ProtoToGql.convert(TestEnum.getDescriptor());
 
     GraphQLEnumValueDefinition graphQLFieldDefinition = nestedEnumType.getValue("UNKNOWN");
     assertThat(graphQLFieldDefinition.getDescription().equals("Some trailing comment")).isTrue();
 
-    GraphQLObjectType nestedMessageType = ProtoToGql.convert(Proto2.NestedProto.getDescriptor(), null);
+    GraphQLObjectType nestedMessageType =
+        ProtoToGql.convert(Proto2.NestedProto.getDescriptor(), null);
 
     assertThat(nestedMessageType.getDescription().equals("Nested type comment")).isTrue();
 
-    GraphQLFieldDefinition nestedFieldGraphQLFieldDefinition = nestedMessageType.getFieldDefinition("nestedId");
+    GraphQLFieldDefinition nestedFieldGraphQLFieldDefinition =
+        nestedMessageType.getFieldDefinition("nestedId");
     assertThat(nestedFieldGraphQLFieldDefinition).isNotNull();
-    assertThat(nestedFieldGraphQLFieldDefinition.getDescription().equals("Some nested id")).isTrue();
+    assertThat(nestedFieldGraphQLFieldDefinition.getDescription().equals("Some nested id"))
+        .isTrue();
 
     GraphQLEnumType enumType = ProtoToGql.convert(TestProto.TestEnumWithComments.getDescriptor());
 
     graphQLFieldDefinition = enumType.getValue("FOO");
     assertThat(graphQLFieldDefinition.getDescription().equals("Some trailing comment")).isTrue();
-
   }
-
 }

--- a/rejoiner/src/test/java/com/google/api/graphql/rejoiner/RejoinerIntegrationTest.java
+++ b/rejoiner/src/test/java/com/google/api/graphql/rejoiner/RejoinerIntegrationTest.java
@@ -16,10 +16,6 @@ package com.google.api.graphql.rejoiner;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import com.google.api.graphql.rejoiner.Greetings.ExtraProto;
 import com.google.api.graphql.rejoiner.Greetings.GreetingsRequest;
 import com.google.api.graphql.rejoiner.Greetings.GreetingsResponse;
@@ -42,6 +38,9 @@ import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLSchema;
 import io.grpc.Status;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -104,17 +103,15 @@ public final class RejoinerIntegrationTest {
       return Futures.immediateFuture(request.toBuilder().setSomeValue(source.getId()).build());
     }
 
-      @Query("greetingWithException")
-      ListenableFuture<GreetingsResponse> greetingsWithException(GreetingsRequest request) {
-        throw Status.UNIMPLEMENTED
-                .withDescription("message from service")
-                .asRuntimeException();
-      }
+    @Query("greetingWithException")
+    ListenableFuture<GreetingsResponse> greetingsWithException(GreetingsRequest request) {
+      throw Status.UNIMPLEMENTED.withDescription("message from service").asRuntimeException();
+    }
 
-      @Query("greetingWithGraphQLError")
-      ListenableFuture<GreetingsResponse> greetingsWithGraphqlError(GreetingsRequest request) {
-        throw new SampleGraphQLException();
-      }
+    @Query("greetingWithGraphQLError")
+    ListenableFuture<GreetingsResponse> greetingsWithGraphqlError(GreetingsRequest request) {
+      throw new SampleGraphQLException();
+    }
   }
 
   static class GreetingsAddonSchemaModule extends SchemaModule {
@@ -137,16 +134,18 @@ public final class RejoinerIntegrationTest {
 
   @Test
   public void schemaShouldList() {
-    GraphQLOutputType listOfStuff = schema.getQueryType().getFieldDefinition("listOfStuff").getType();
+    GraphQLOutputType listOfStuff =
+        schema.getQueryType().getFieldDefinition("listOfStuff").getType();
     assertThat(listOfStuff).isInstanceOf(GraphQLList.class);
-    assertThat(((GraphQLList)listOfStuff).getWrappedType()).isInstanceOf(GraphQLNonNull.class);
+    assertThat(((GraphQLList) listOfStuff).getWrappedType()).isInstanceOf(GraphQLNonNull.class);
   }
 
   @Test
   public void schemaShouldListSync() {
-    GraphQLOutputType listOfStuff = schema.getQueryType().getFieldDefinition("listOfStuffSync").getType();
+    GraphQLOutputType listOfStuff =
+        schema.getQueryType().getFieldDefinition("listOfStuffSync").getType();
     assertThat(listOfStuff).isInstanceOf(GraphQLList.class);
-    assertThat(((GraphQLList)listOfStuff).getWrappedType()).isInstanceOf(GraphQLNonNull.class);
+    assertThat(((GraphQLList) listOfStuff).getWrappedType()).isInstanceOf(GraphQLNonNull.class);
   }
 
   @Test
@@ -167,28 +166,28 @@ public final class RejoinerIntegrationTest {
 
   @Test
   public void handlesRuntimeExceptionMessage() {
-    GraphQL graphQL = GraphQL.newGraphQL(schema)
-            .build();
+    GraphQL graphQL = GraphQL.newGraphQL(schema).build();
 
-    ExecutionInput executionInput = ExecutionInput.newExecutionInput()
-            .query("query { greetingWithException { id } }")
-            .build();
+    ExecutionInput executionInput =
+        ExecutionInput.newExecutionInput().query("query { greetingWithException { id } }").build();
 
     ExecutionResult executionResult = graphQL.execute(executionInput);
 
     assertThat(executionResult.getErrors()).hasSize(1);
     GraphQLError graphQLError = executionResult.getErrors().get(0);
-    assertThat(graphQLError.getMessage()).isEqualTo("Exception while fetching data (/greetingWithException) : UNIMPLEMENTED: message from service");
+    assertThat(graphQLError.getMessage())
+        .isEqualTo(
+            "Exception while fetching data (/greetingWithException) : UNIMPLEMENTED: message from service");
     assertThat(graphQLError.getPath()).hasSize(1);
     assertThat(graphQLError.getPath().get(0)).isEqualTo("greetingWithException");
   }
 
   @Test
   public void handlesGraphQLError() {
-    GraphQL graphQL = GraphQL.newGraphQL(schema)
-            .build();
+    GraphQL graphQL = GraphQL.newGraphQL(schema).build();
 
-    ExecutionInput executionInput = ExecutionInput.newExecutionInput()
+    ExecutionInput executionInput =
+        ExecutionInput.newExecutionInput()
             .query("query { greetingWithGraphQLError { id } }")
             .build();
 
@@ -196,7 +195,8 @@ public final class RejoinerIntegrationTest {
 
     assertThat(executionResult.getErrors()).hasSize(1);
     GraphQLError graphQLError = executionResult.getErrors().get(0);
-    assertThat(graphQLError.getMessage()).isEqualTo("Exception while fetching data (/greetingWithGraphQLError) : Test GraphQLError");
+    assertThat(graphQLError.getMessage())
+        .isEqualTo("Exception while fetching data (/greetingWithGraphQLError) : Test GraphQLError");
     assertThat(graphQLError.getExtensions()).containsEntry("error", "message");
     assertThat(graphQLError.getPath()).hasSize(1);
     assertThat(graphQLError.getPath().get(0)).isEqualTo("greetingWithGraphQLError");

--- a/rejoiner/src/test/java/com/google/api/graphql/rejoiner/SchemaModuleTest.java
+++ b/rejoiner/src/test/java/com/google/api/graphql/rejoiner/SchemaModuleTest.java
@@ -36,7 +36,6 @@ import graphql.Scalars;
 import graphql.execution.ExecutionContextBuilder;
 import graphql.execution.ExecutionId;
 import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.DataFetchingEnvironmentBuilder;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLFieldDefinition;
 
@@ -51,15 +50,12 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public final class SchemaModuleTest {
 
-  private static final Key<Set<GraphQLFieldDefinition>> QUERY_KEY =
-      Key.get(new TypeLiteral<Set<GraphQLFieldDefinition>>() {}, Queries.class);
-  private static final Key<Set<GraphQLFieldDefinition>> MUTATION_KEY =
-      Key.get(new TypeLiteral<Set<GraphQLFieldDefinition>>() {}, Mutations.class);
-  private static final Key<Set<FileDescriptor>> EXTRA_TYPE_KEY =
-      Key.get(new TypeLiteral<Set<FileDescriptor>>() {}, ExtraTypes.class);
-  private static final Key<Set<TypeModification>> MODIFICATION_KEY =
-      Key.get(new TypeLiteral<Set<TypeModification>>() {}, GraphModifications.class);
+  private static final Key<Set<SchemaBundle>>  =
+      Key.get(new TypeLiteral<Set<SchemaBundle>>() {}, Annotations.SchemaBundles.class);
 
+//    Multibinder<SchemaBundle> schemaBundleProviders =
+//            Multibinder.newSetBinder(
+//                    binder(), new TypeLiteral<SchemaBundle>() {}, Annotations.SchemaBundles.class);
   @Test
   public void schemaModuleShouldProvideEmpty() {
     Injector injector = Guice.createInjector(new SchemaModule() {});
@@ -79,7 +75,6 @@ public final class SchemaModuleTest {
                   GraphQLFieldDefinition.newFieldDefinition()
                       .name("greeting")
                       .type(Scalars.GraphQLString)
-                      .staticValue("hello world")
                       .build();
             });
     assertThat(injector.getInstance(QUERY_KEY)).hasSize(1);
@@ -98,7 +93,6 @@ public final class SchemaModuleTest {
                   GraphQLFieldDefinition.newFieldDefinition()
                       .name("queryField")
                       .type(Scalars.GraphQLString)
-                      .staticValue("hello world")
                       .build();
 
               @Mutation
@@ -106,7 +100,6 @@ public final class SchemaModuleTest {
                   GraphQLFieldDefinition.newFieldDefinition()
                       .name("mutationField")
                       .type(Scalars.GraphQLString)
-                      .staticValue("hello world")
                       .build();
 
               @Query("queryMethod")
@@ -135,7 +128,6 @@ public final class SchemaModuleTest {
           GraphQLFieldDefinition.newFieldDefinition()
               .name("queryField")
               .type(Scalars.GraphQLString)
-              .staticValue("hello world")
               .build();
 
       @Mutation
@@ -143,7 +135,6 @@ public final class SchemaModuleTest {
           GraphQLFieldDefinition.newFieldDefinition()
               .name("mutationField")
               .type(Scalars.GraphQLString)
-              .staticValue("hello world")
               .build();
 
       @Query("queryMethod")
@@ -250,21 +241,22 @@ public final class SchemaModuleTest {
     assertThat(hello.getType().getName())
         .isEqualTo("javatests_com_google_api_graphql_rejoiner_proto_GreetingsResponse");
 
-    Object result =
-        hello
-            .getDataFetcher()
-            .get(
-                DataFetchingEnvironmentBuilder.newDataFetchingEnvironment()
-                    .executionContext(
-                        ExecutionContextBuilder.newExecutionContextBuilder()
-                            .executionId(ExecutionId.from("1"))
-                            .build())
-                    .arguments(ImmutableMap.of("input", ImmutableMap.of("id", "123")))
-                    .build());
-
-    assertThat(result).isInstanceOf(ListenableFuture.class);
-    assertThat(((ListenableFuture<?>) result).get())
-        .isEqualTo(GreetingsResponse.newBuilder().setId("123").build());
+    // TODO: migrate test to use GraphQLCodeRegistry
+    //    Object result =
+    //        hello
+    //            .getDataFetcher()
+    //            .get(
+    //                DataFetchingEnvironmentBuilder.newDataFetchingEnvironment()
+    //                    .executionContext(
+    //                        ExecutionContextBuilder.newExecutionContextBuilder()
+    //                            .executionId(ExecutionId.from("1"))
+    //                            .build())
+    //                    .arguments(ImmutableMap.of("input", ImmutableMap.of("id", "123")))
+    //                    .build());
+    //
+    //    assertThat(result).isInstanceOf(ListenableFuture.class);
+    //    assertThat(((ListenableFuture<?>) result).get())
+    //        .isEqualTo(GreetingsResponse.newBuilder().setId("123").build());
   }
 
   @Test(expected = CreationException.class)

--- a/rejoiner/src/test/java/com/google/api/graphql/rejoiner/SchemaModuleTest.java
+++ b/rejoiner/src/test/java/com/google/api/graphql/rejoiner/SchemaModuleTest.java
@@ -30,6 +30,7 @@ import graphql.Scalars;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLFieldDefinition;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import org.junit.Test;
@@ -218,7 +219,7 @@ public final class SchemaModuleTest {
     assertThat(schemaBundle.mutationFields()).isEmpty();
     assertThat(schemaBundle.fileDescriptors()).hasSize(1);
     assertThat(schemaBundle.modifications()).isEmpty();
-    Set<GraphQLFieldDefinition> queryFields = schemaBundle.queryFields();
+    Collection<GraphQLFieldDefinition> queryFields = schemaBundle.queryFields();
     GraphQLFieldDefinition hello = queryFields.iterator().next();
     assertThat(hello.getName()).isEqualTo("hello");
     assertThat(hello.getArguments()).hasSize(1);

--- a/rejoiner/src/test/java/com/google/api/graphql/rejoiner/TypeTest.java
+++ b/rejoiner/src/test/java/com/google/api/graphql/rejoiner/TypeTest.java
@@ -34,7 +34,6 @@ public final class TypeTest {
           .field(
               GraphQLFieldDefinition.newFieldDefinition()
                   .name("name")
-                  .staticValue("rejoiner")
                   .type(Scalars.GraphQLString)
                   .build())
           .build();
@@ -46,7 +45,6 @@ public final class TypeTest {
             .addField(
                 GraphQLFieldDefinition.newFieldDefinition()
                     .name("isTheBest")
-                    .staticValue(true)
                     .type(Scalars.GraphQLBoolean)
                     .build());
 
@@ -66,16 +64,10 @@ public final class TypeTest {
             .replaceField(
                 GraphQLFieldDefinition.newFieldDefinition()
                     .name("name")
-                    .staticValue("rejoinerv2")
-                    .type(Scalars.GraphQLString)
+                    .type(Scalars.GraphQLInt)
                     .build());
-    assertThat(
-            typeModification
-                .apply(OBJECT_TYPE)
-                .getFieldDefinition("name")
-                .getDataFetcher()
-                .get(null))
-        .isEqualTo("rejoinerv2");
+    assertThat(typeModification.apply(OBJECT_TYPE).getFieldDefinition("name").getType())
+        .isEqualTo(Scalars.GraphQLInt);
   }
 
   @Test(expected = AssertException.class)
@@ -84,7 +76,6 @@ public final class TypeTest {
         .addField(
             GraphQLFieldDefinition.newFieldDefinition()
                 .name("name")
-                .staticValue("rejoiner2")
                 .type(Scalars.GraphQLString)
                 .build())
         .apply(OBJECT_TYPE);


### PR DESCRIPTION
Simplified internal guice bindings.
Temporarily removes support for Relay node interface.
Allows delayed Schema construction and injection by using providers internally.
Initial work to migrate off of deprecated GraphQL DataFetcher fields on object types.