### PR TITLE
Separate guice

### DIFF
--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaBundle.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaBundle.java
@@ -4,11 +4,70 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Descriptors;
+import graphql.relay.Relay;
 import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+
 import java.util.Collection;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static graphql.schema.GraphQLObjectType.newObject;
 
 @AutoValue
 public abstract class SchemaBundle {
+
+  public GraphQLSchema toSchema() {
+    Map<String, ? extends Function<String, Object>> nodeDataFetchers =
+            nodeDataFetchers()
+                    .stream()
+                    .collect(Collectors.toMap(e -> e.getClassName(), Function.identity()));
+
+    GraphQLObjectType.Builder queryType =
+            newObject().name("QueryType").fields(queryFields());
+
+    ProtoRegistry protoRegistry =
+            ProtoRegistry.newBuilder()
+                    .addAll(fileDescriptors())
+                    .add(modifications())
+                    .build();
+
+    if (protoRegistry.hasRelayNode()) {
+      queryType.field(
+              new Relay()
+                      .nodeField(
+                              protoRegistry.getRelayNode(),
+                              environment -> {
+                                String id = environment.getArgument("id");
+                                Relay.ResolvedGlobalId resolvedGlobalId = new Relay().fromGlobalId(id);
+                                Function<String, ?> stringFunction =
+                                        nodeDataFetchers.get(resolvedGlobalId.getType());
+                                if (stringFunction == null) {
+                                  throw new RuntimeException(
+                                          String.format(
+                                                  "Relay Node fetcher not implemented for type=%s",
+                                                  resolvedGlobalId.getType()));
+                                }
+                                return stringFunction.apply(resolvedGlobalId.getId());
+                              }));
+    }
+
+    if (mutationFields().isEmpty()) {
+      return GraphQLSchema.newSchema()
+              .query(queryType)
+              .additionalTypes(protoRegistry.listTypes())
+              .build();
+    }
+    GraphQLObjectType mutationType =
+            newObject().name("MutationType").fields(mutationFields()).build();
+    return GraphQLSchema.newSchema()
+            .query(queryType)
+            .mutation(mutationType)
+            .additionalTypes(protoRegistry.listTypes())
+            .build();
+  }
 
   public abstract ImmutableList<GraphQLFieldDefinition> queryFields();
 
@@ -27,13 +86,13 @@ public abstract class SchemaBundle {
   public static SchemaBundle combine(Collection<SchemaBundle> schemaBundles) {
     Builder builder = SchemaBundle.builder();
     schemaBundles.forEach(
-        schemaBundle -> {
-          builder.queryFieldsBuilder().addAll(schemaBundle.queryFields());
-          builder.mutationFieldsBuilder().addAll(schemaBundle.mutationFields());
-          builder.modificationsBuilder().addAll(schemaBundle.modifications());
-          builder.fileDescriptorsBuilder().addAll(schemaBundle.fileDescriptors());
-          builder.nodeDataFetchersBuilder().addAll(schemaBundle.nodeDataFetchers());
-        });
+            schemaBundle -> {
+              builder.queryFieldsBuilder().addAll(schemaBundle.queryFields());
+              builder.mutationFieldsBuilder().addAll(schemaBundle.mutationFields());
+              builder.modificationsBuilder().addAll(schemaBundle.modifications());
+              builder.fileDescriptorsBuilder().addAll(schemaBundle.fileDescriptors());
+              builder.nodeDataFetchersBuilder().addAll(schemaBundle.nodeDataFetchers());
+            });
     return builder.build();
   }
 

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaBundle.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaBundle.java
@@ -1,5 +1,7 @@
 package com.google.api.graphql.rejoiner;
 
+import static graphql.schema.GraphQLObjectType.newObject;
+
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -8,65 +10,57 @@ import graphql.relay.Relay;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
-
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import static graphql.schema.GraphQLObjectType.newObject;
 
 @AutoValue
 public abstract class SchemaBundle {
 
   public GraphQLSchema toSchema() {
     Map<String, ? extends Function<String, Object>> nodeDataFetchers =
-            nodeDataFetchers()
-                    .stream()
-                    .collect(Collectors.toMap(e -> e.getClassName(), Function.identity()));
+        nodeDataFetchers().stream()
+            .collect(Collectors.toMap(e -> e.getClassName(), Function.identity()));
 
-    GraphQLObjectType.Builder queryType =
-            newObject().name("QueryType").fields(queryFields());
+    GraphQLObjectType.Builder queryType = newObject().name("QueryType").fields(queryFields());
 
     ProtoRegistry protoRegistry =
-            ProtoRegistry.newBuilder()
-                    .addAll(fileDescriptors())
-                    .add(modifications())
-                    .build();
+        ProtoRegistry.newBuilder().addAll(fileDescriptors()).add(modifications()).build();
 
     if (protoRegistry.hasRelayNode()) {
       queryType.field(
-              new Relay()
-                      .nodeField(
-                              protoRegistry.getRelayNode(),
-                              environment -> {
-                                String id = environment.getArgument("id");
-                                Relay.ResolvedGlobalId resolvedGlobalId = new Relay().fromGlobalId(id);
-                                Function<String, ?> stringFunction =
-                                        nodeDataFetchers.get(resolvedGlobalId.getType());
-                                if (stringFunction == null) {
-                                  throw new RuntimeException(
-                                          String.format(
-                                                  "Relay Node fetcher not implemented for type=%s",
-                                                  resolvedGlobalId.getType()));
-                                }
-                                return stringFunction.apply(resolvedGlobalId.getId());
-                              }));
+          new Relay()
+              .nodeField(
+                  protoRegistry.getRelayNode(),
+                  environment -> {
+                    String id = environment.getArgument("id");
+                    Relay.ResolvedGlobalId resolvedGlobalId = new Relay().fromGlobalId(id);
+                    Function<String, ?> stringFunction =
+                        nodeDataFetchers.get(resolvedGlobalId.getType());
+                    if (stringFunction == null) {
+                      throw new RuntimeException(
+                          String.format(
+                              "Relay Node fetcher not implemented for type=%s",
+                              resolvedGlobalId.getType()));
+                    }
+                    return stringFunction.apply(resolvedGlobalId.getId());
+                  }));
     }
 
     if (mutationFields().isEmpty()) {
       return GraphQLSchema.newSchema()
-              .query(queryType)
-              .additionalTypes(protoRegistry.listTypes())
-              .build();
+          .query(queryType)
+          .additionalTypes(protoRegistry.listTypes())
+          .build();
     }
     GraphQLObjectType mutationType =
-            newObject().name("MutationType").fields(mutationFields()).build();
+        newObject().name("MutationType").fields(mutationFields()).build();
     return GraphQLSchema.newSchema()
-            .query(queryType)
-            .mutation(mutationType)
-            .additionalTypes(protoRegistry.listTypes())
-            .build();
+        .query(queryType)
+        .mutation(mutationType)
+        .additionalTypes(protoRegistry.listTypes())
+        .build();
   }
 
   public abstract ImmutableList<GraphQLFieldDefinition> queryFields();
@@ -86,13 +80,13 @@ public abstract class SchemaBundle {
   public static SchemaBundle combine(Collection<SchemaBundle> schemaBundles) {
     Builder builder = SchemaBundle.builder();
     schemaBundles.forEach(
-            schemaBundle -> {
-              builder.queryFieldsBuilder().addAll(schemaBundle.queryFields());
-              builder.mutationFieldsBuilder().addAll(schemaBundle.mutationFields());
-              builder.modificationsBuilder().addAll(schemaBundle.modifications());
-              builder.fileDescriptorsBuilder().addAll(schemaBundle.fileDescriptors());
-              builder.nodeDataFetchersBuilder().addAll(schemaBundle.nodeDataFetchers());
-            });
+        schemaBundle -> {
+          builder.queryFieldsBuilder().addAll(schemaBundle.queryFields());
+          builder.mutationFieldsBuilder().addAll(schemaBundle.mutationFields());
+          builder.modificationsBuilder().addAll(schemaBundle.modifications());
+          builder.fileDescriptorsBuilder().addAll(schemaBundle.fileDescriptors());
+          builder.nodeDataFetchersBuilder().addAll(schemaBundle.nodeDataFetchers());
+        });
     return builder.build();
   }
 

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaDefinitionReader.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaDefinitionReader.java
@@ -1,0 +1,564 @@
+// Copyright 2017 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.api.graphql.rejoiner;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.Message;
+import graphql.Scalars;
+import graphql.schema.*;
+
+import javax.annotation.Nullable;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class that inspects fields and methods on a "schema definition" object.
+ * This results in a {@link SchemaBundle} which can then be turned into a schema.
+ *
+ * <p>Any public fields of type {@link GraphQLFieldDefinition} annotated with {@link Query} or
+ * {@link Mutation} will be added to the top level query or mutation. Fields of type {@link
+ * TypeModification} annotated with {@link SchemaModification} will be applied to the generated
+ * schema in order to add, remove, or replace fields on a GraphQL type. Fields of type {@link
+ * FileDescriptor} annotated with {@link ExtraType} will be available to GraphQL when creating the
+ * final schema.
+ */
+public class SchemaDefinitionReader {
+
+  private final ImmutableSet.Builder<Descriptor> referencedDescriptors = ImmutableSet.builder();
+  private final List<GraphQLFieldDefinition> allQueriesInModule = new ArrayList<>();
+  private final List<GraphQLFieldDefinition> allMutationsInModule = new ArrayList<>();
+
+  /**
+   * Returns a reference to the GraphQL type corresponding to the supplied proto.
+   *
+   * <p>All types in the proto are made available to be included in the GraphQL schema.
+   */
+  protected final GraphQLTypeReference getTypeReference(Descriptor descriptor) {
+    referencedDescriptors.add(descriptor);
+    return ProtoToGql.getReference(descriptor);
+  }
+
+  protected final GraphQLTypeReference getInputTypeReference(Descriptor descriptor) {
+    referencedDescriptors.add(descriptor);
+    return new GraphQLTypeReference(GqlInputConverter.getReferenceName(descriptor));
+  }
+
+  protected ImmutableList<GraphQLFieldDefinition> extraMutations() {
+    return ImmutableList.of();
+  }
+
+  protected void addQuery(GraphQLFieldDefinition query) {
+    allQueriesInModule.add(query);
+  }
+
+  protected void addMutation(GraphQLFieldDefinition mutation) {
+    allMutationsInModule.add(mutation);
+  }
+
+  protected void addQueryList(List<GraphQLFieldDefinition> queries) {
+    allQueriesInModule.addAll(queries);
+  }
+
+  protected void addMutationList(List<GraphQLFieldDefinition> mutations) {
+    allMutationsInModule.addAll(mutations);
+  }
+
+  public SchemaBundle createBundle(final Object schemaDefinition) {
+    final Class<?> moduleClass = schemaDefinition.getClass();
+
+    for (Method method : findMethods(moduleClass, Query.class)) {
+      Query query = method.getAnnotationsByType(Query.class)[0];
+      allQueriesInModule.add(
+              methodToFieldDefinition(schemaDefinition, method, query.value(), query.fullName(), null));
+    }
+    for (Method method : findMethods(moduleClass, Mutation.class)) {
+      Mutation mutation = method.getAnnotationsByType(Mutation.class)[0];
+      allMutationsInModule.add(
+              methodToFieldDefinition(schemaDefinition, method, mutation.value(), mutation.fullName(), null));
+    }
+
+    final List<NodeDataFetcher> nodeDataFetchers = new ArrayList<>();
+    final List<TypeModification> schemaModifications = new ArrayList<>();
+
+    for (Method method : findMethods(moduleClass, RelayNode.class)) {
+      GraphQLFieldDefinition graphQLFieldDefinition =
+              methodToFieldDefinition(schemaDefinition, method, "_NOT_USED_", "_NOT_USED_", null);
+      nodeDataFetchers.add(
+              new NodeDataFetcher(graphQLFieldDefinition.getType().getName()) {
+                @Override
+                public Object apply(String s) {
+                  // TODO: Don't hardcode the arguments structure.
+                  try {
+                    return null;
+                    //                      return graphQLFieldDefinition
+                    //                              .getDataFetcher()
+                    //                              .get(
+                    //
+                    // DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                    //
+                    // .arguments(ImmutableMap.of("input", ImmutableMap.of("id",
+                    // s)))
+                    //                                  .build());
+                  } catch (Exception e) {
+                    throw new RuntimeException(e);
+                  }
+                }
+              });
+    }
+    try {
+      for (Method method : findMethods(moduleClass, SchemaModification.class)) {
+        SchemaModification annotation = method.getAnnotationsByType(SchemaModification.class)[0];
+        String name = annotation.addField();
+        Class<?> typeClass = annotation.onType();
+        Descriptor typeDescriptor = (Descriptor) typeClass.getMethod("getDescriptor").invoke(null);
+        referencedDescriptors.add(typeDescriptor);
+        schemaModifications.add(methodToTypeModification(schemaDefinition, method, name, typeDescriptor));
+      }
+    } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+
+    SchemaBundle.Builder schemaBundleBuilder = SchemaBundle.builder();
+
+    allMutationsInModule.addAll(extraMutations());
+
+    try {
+      for (Field field : findQueryFields(moduleClass)) {
+        field.setAccessible(true);
+        allQueriesInModule.add((GraphQLFieldDefinition) field.get(schemaDefinition));
+      }
+
+      for (Field field : findMutationFields(moduleClass)) {
+        field.setAccessible(true);
+        allMutationsInModule.add((GraphQLFieldDefinition) field.get(schemaDefinition));
+      }
+
+      for (Field field : findTypeModificationFields(moduleClass)) {
+        field.setAccessible(true);
+        schemaBundleBuilder
+                .modificationsBuilder()
+                .add((TypeModification) field.get(schemaDefinition));
+      }
+
+      for (Field field : findExtraTypeFields(moduleClass)) {
+        field.setAccessible(true);
+        schemaBundleBuilder
+                .fileDescriptorsBuilder()
+                .add((FileDescriptor) field.get(schemaDefinition));
+      }
+
+      Namespace namespaceAnnotation = findClassAnnotation(moduleClass, Namespace.class);
+
+      if (namespaceAnnotation == null) {
+        schemaBundleBuilder.mutationFieldsBuilder().addAll(allMutationsInModule);
+        schemaBundleBuilder.queryFieldsBuilder().addAll(allQueriesInModule);
+      } else {
+        String namespace = namespaceAnnotation.value();
+        if (!allQueriesInModule.isEmpty()) {
+          schemaBundleBuilder
+                  .queryFieldsBuilder()
+                  .add(
+                          GraphQLFieldDefinition.newFieldDefinition()
+                                  .staticValue("")
+                                  .name(namespace)
+                                  .description(namespace)
+                                  .type(
+                                          GraphQLObjectType.newObject()
+                                                  .name("_QUERY_FIELD_GROUP_" + namespace)
+                                                  .fields(allQueriesInModule)
+                                                  .build())
+                                  .build());
+        }
+        if (!allMutationsInModule.isEmpty()) {
+          schemaBundleBuilder
+                  .mutationFieldsBuilder()
+                  .add(
+                          GraphQLFieldDefinition.newFieldDefinition()
+                                  .staticValue("")
+                                  .name(namespace)
+                                  .description(namespace)
+                                  .type(
+                                          GraphQLObjectType.newObject()
+                                                  .name("_MUTATION_FIELD_GROUP_" + namespace)
+                                                  .fields(allMutationsInModule)
+                                                  .build())
+                                  .build());
+        }
+      }
+
+      schemaBundleBuilder.nodeDataFetchersBuilder().addAll(nodeDataFetchers);
+      schemaBundleBuilder.modificationsBuilder().addAll(schemaModifications);
+
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+
+    referencedDescriptors
+            .build()
+            .forEach(
+                    descriptor ->
+                            schemaBundleBuilder.fileDescriptorsBuilder().add(descriptor.getFile()));
+
+    return schemaBundleBuilder.build();
+  }
+
+  void addExtraType(Descriptor descriptor) {
+    referencedDescriptors.add(descriptor);
+  }
+
+  /**
+   * Returns an {@link ImmutableSet} of all the methods in {@code moduleClass} or its super classes
+   * that are annotated with {@link Query}.
+   *
+   * @param moduleClass
+   */
+  private static ImmutableSet<Field> findTypeModificationFields(
+          Class<?> moduleClass) {
+    return findFields(moduleClass, SchemaModification.class, TypeModification.class);
+  }
+
+  /**
+   * Returns an {@link ImmutableSet} of all the methods in {@code moduleClass} or its super classes
+   * that are annotated with {@link Query}.
+   *
+   * @param moduleClass
+   */
+  private static ImmutableSet<Field> findExtraTypeFields(
+          Class<?> moduleClass) {
+    return findFields(moduleClass, ExtraType.class, FileDescriptor.class);
+  }
+
+  /**
+   * Returns an {@link ImmutableSet} of all the methods in {@code moduleClass} or its super classes
+   * that are annotated with {@link Query}.
+   *
+   * @param moduleClass
+   */
+  private static ImmutableSet<Field> findMutationFields(Class<?> moduleClass) {
+    return findFields(moduleClass, Mutation.class, GraphQLFieldDefinition.class);
+  }
+
+  /**
+   * Returns an {@link ImmutableSet} of all the methods in {@code moduleClass} or its super classes
+   * that are annotated with {@link Query}.
+   *
+   * @param moduleClass
+   */
+  private static ImmutableSet<Field> findQueryFields(Class<?> moduleClass) {
+    return findFields(moduleClass, Query.class, GraphQLFieldDefinition.class);
+  }
+
+  /**
+   * Returns an {@link ImmutableSet} of all the methods in {@code moduleClass} or its super classes
+   * that have the expected type and annotation.
+   */
+  private static ImmutableSet<Method> findMethods(
+          Class<?> moduleClass, Class<? extends Annotation> targetAnnotation) {
+    Class<?> clazz = moduleClass;
+    ImmutableSet.Builder<Method> nodesBuilder = ImmutableSet.builder();
+    while (clazz != null && !SchemaDefinitionReader.class.equals(clazz)) {
+      for (Method method : clazz.getDeclaredMethods()) {
+        if (method.isAnnotationPresent(targetAnnotation)) {
+          nodesBuilder.add(method);
+        }
+      }
+      clazz = clazz.getSuperclass();
+    }
+    return nodesBuilder.build();
+  }
+
+  /**
+   * Returns an {@link ImmutableSet} of all the methods in {@code moduleClass} or its super classes
+   * that have the expected type and annotation.
+   */
+  private static <T extends Annotation> T findClassAnnotation(
+          Class<?> moduleClass, Class<T> targetAnnotation) {
+    Class<?> clazz = moduleClass;
+    while (clazz != null && !SchemaDefinitionReader.class.equals(clazz)) {
+      T annotation = clazz.getAnnotation(targetAnnotation);
+      if (annotation != null) {
+        return annotation;
+      }
+      clazz = clazz.getSuperclass();
+    }
+    return null;
+  }
+
+  /**
+   * Returns an {@link ImmutableSet} of all the fields in {@code moduleClass} or its super classes
+   * that have the expected type and annotation.
+   */
+  private static ImmutableSet<Field> findFields(
+          Class<?> moduleClass,
+          Class<? extends Annotation> targetAnnotation,
+          Class<?> expectedType) {
+    Class<?> clazz = moduleClass;
+    ImmutableSet.Builder<Field> nodesBuilder = ImmutableSet.builder();
+    while (clazz != null && !SchemaDefinitionReader.class.equals(clazz)) {
+      for (Field method : clazz.getDeclaredFields()) {
+        if (method.isAnnotationPresent(targetAnnotation)) {
+          Preconditions.checkArgument(
+                  method.getType() == expectedType,
+                  "Field %s should be type %s",
+                  method,
+                  expectedType.getSimpleName());
+          nodesBuilder.add(method);
+        }
+      }
+      clazz = clazz.getSuperclass();
+    }
+    return nodesBuilder.build();
+  }
+
+  /**
+   * Override to implement additional parametertypes
+   */
+  protected Function<DataFetchingEnvironment, Object> handleParameter(Method method, int parameterIndex) {
+    return null;
+  }
+
+  @AutoValue
+  abstract static class MethodMetadata {
+    @Nullable
+    abstract Function<DataFetchingEnvironment, ?> function();
+
+    @Nullable
+    abstract GraphQLArgument argument();
+
+    static MethodMetadata create(
+            Function<DataFetchingEnvironment, ?> value, GraphQLArgument argument) {
+      return new AutoValue_SchemaDefinition_MethodMetadata(value, argument);
+    }
+
+    static MethodMetadata create(Function<DataFetchingEnvironment, ?> value) {
+      return new AutoValue_SchemaDefinition_MethodMetadata(value, null);
+    }
+
+    Object getParameterValue(DataFetchingEnvironment environment) {
+      return function().apply(environment);
+    }
+
+    boolean hasArgument() {
+      return argument() != null;
+    }
+
+  }
+
+  private TypeModification methodToTypeModification(
+          Object module, Method method, String name, Descriptor typeDescriptor) {
+    GraphQLFieldDefinition fieldDef = methodToFieldDefinition(module, method, name, name, typeDescriptor);
+    return Type.find(typeDescriptor).addField(fieldDef);
+  }
+
+  private GraphQLFieldDefinition methodToFieldDefinition(
+          Object module, Method method, String name, @Nullable String fullName, @Nullable Descriptor descriptor) {
+    method.setAccessible(true);
+    try {
+      ImmutableList<MethodMetadata> methodParameters = getMethodMetadata(method, descriptor);
+      DataFetcher dataFetcher =
+              (DataFetchingEnvironment environment) -> {
+                Object[] methodParameterValues = new Object[methodParameters.size()];
+                for (int i = 0; i < methodParameters.size(); i++) {
+                  methodParameterValues[i] = methodParameters.get(i).getParameterValue(environment);
+                }
+                try {
+                  return method.invoke(module, methodParameterValues);
+                } catch (InvocationTargetException e) {
+                  Throwable cause = e.getCause();
+                  if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
+                  }
+                  throw new RuntimeException(cause);
+                } catch (Exception e) {
+                  throw new RuntimeException(e);
+                }
+              };
+
+      GraphQLOutputType returnType = getReturnType(method);
+
+      // Create GraphQL Field Definition
+      GraphQLFieldDefinition.Builder fieldDef = GraphQLFieldDefinition.newFieldDefinition();
+      fieldDef.type(returnType);
+      fieldDef.name(name);
+      fieldDef.description(DescriptorSet.COMMENTS.get(fullName));
+      for (MethodMetadata methodMetadata : methodParameters) {
+        if (methodMetadata.hasArgument()) {
+          fieldDef.argument(methodMetadata.argument());
+        }
+      }
+      fieldDef.dataFetcher(dataFetcher);
+      return fieldDef.build();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  ImmutableMap<java.lang.reflect.Type, GraphQLScalarType> javaTypeToScalarMap =
+          ImmutableMap.of(
+                  String.class, Scalars.GraphQLString,
+                  Integer.class, Scalars.GraphQLInt,
+                  Boolean.class, Scalars.GraphQLBoolean,
+                  Long.class, Scalars.GraphQLLong,
+                  Float.class, Scalars.GraphQLFloat);
+
+  private GraphQLOutputType getReturnType(Method method)
+          throws IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+    // Currently it's assumed the response is of type Message, ListenableFuture<? extends
+    // Message>, ImmutableList<Message>, ListenableFuture<ImmutableList<? extend Message>>, oe
+    // any Scalar type.
+
+    // Assume Message or Scalar
+    if (!(method.getGenericReturnType() instanceof ParameterizedType)) {
+      Class<?> returnType = method.getReturnType();
+      if (Message.class.isAssignableFrom(returnType)) {
+        @SuppressWarnings("unchecked")
+        Class<? extends Message> responseClass = (Class<? extends Message>) method.getReturnType();
+        Descriptor responseDescriptor =
+                (Descriptor) responseClass.getMethod("getDescriptor").invoke(null);
+        referencedDescriptors.add(responseDescriptor);
+        return ProtoToGql.getReference(responseDescriptor);
+      }
+      if (javaTypeToScalarMap.containsKey(returnType)) {
+        return javaTypeToScalarMap.get(returnType);
+      }
+      throw new RuntimeException("Unknown scalar type: " + returnType.getTypeName());
+    }
+
+    ParameterizedType genericReturnType = (ParameterizedType) method.getGenericReturnType();
+    // TODO: handle collections of Java Scalars
+
+    // Assume ListenableFuture<ImmutableList<? extends Message>>
+    java.lang.reflect.Type genericTypeValue = genericReturnType.getActualTypeArguments()[0];
+    if (genericTypeValue instanceof ParameterizedType) {
+      java.lang.reflect.Type listElType =
+              ((ParameterizedType) genericTypeValue).getActualTypeArguments()[0];
+      @SuppressWarnings("unchecked")
+      Class<? extends Message> responseClass = (Class<? extends Message>) listElType;
+      Descriptor responseDescriptor =
+              (Descriptor) responseClass.getMethod("getDescriptor").invoke(null);
+      referencedDescriptors.add(responseDescriptor);
+      return new GraphQLList(new GraphQLNonNull(ProtoToGql.getReference(responseDescriptor)));
+    }
+
+    // ImmutableList<? extends Message>
+    if (ImmutableList.class.isAssignableFrom((Class<?>) genericReturnType.getRawType())) {
+      @SuppressWarnings("unchecked")
+      Class<? extends Message> responseClass = (Class<? extends Message>) genericTypeValue;
+      Descriptor responseDescriptor =
+              (Descriptor) responseClass.getMethod("getDescriptor").invoke(null);
+      referencedDescriptors.add(responseDescriptor);
+      return new GraphQLList(new GraphQLNonNull(ProtoToGql.getReference(responseDescriptor)));
+    }
+
+    // ListenableFuture<? extends Message>
+    @SuppressWarnings("unchecked")
+    Class<? extends Message> responseClass =
+            (Class<? extends Message>) genericReturnType.getActualTypeArguments()[0];
+    Descriptor responseDescriptor =
+            (Descriptor) responseClass.getMethod("getDescriptor").invoke(null);
+    referencedDescriptors.add(responseDescriptor);
+    return ProtoToGql.getReference(responseDescriptor);
+  }
+
+  private ImmutableList<MethodMetadata> getMethodMetadata(
+          Method method, @Nullable Descriptor sourceDescriptor)
+          throws IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+    final Class<?>[] parameterTypes = method.getParameterTypes();
+
+    ImmutableList.Builder<MethodMetadata> listBuilder = ImmutableList.builder();
+    for (int i = 0; i < parameterTypes.length; i++) {
+
+      Class<?> parameterType = parameterTypes[i];
+      if (Message.class.isAssignableFrom(parameterType)) {
+        @SuppressWarnings("unchecked")
+        Class<? extends Message> requestClass = (Class<? extends Message>) parameterType;
+        Descriptor requestDescriptor =
+                (Descriptor) requestClass.getMethod("getDescriptor").invoke(null);
+        if (sourceDescriptor != null
+                && requestDescriptor.getFullName().equals(sourceDescriptor.getFullName())) {
+          Function<DataFetchingEnvironment, ?> function = environment -> environment.getSource();
+          listBuilder.add(MethodMetadata.create(function));
+        } else {
+          GqlInputConverter inputConverter =
+                  GqlInputConverter.newBuilder().add(requestDescriptor.getFile()).build();
+          addExtraType(requestDescriptor);
+          Message message =
+                  ((Message.Builder) requestClass.getMethod("newBuilder").invoke(null)).build();
+          String argName = getArgName(method.getParameterAnnotations()[i]);
+          Function<DataFetchingEnvironment, ?> function =
+                  environment -> {
+                    Message req =
+                            inputConverter.createProtoBuf(
+                                    requestDescriptor, message.toBuilder(), environment.getArgument(argName));
+                    return req;
+                  };
+          GraphQLArgument argument = GqlInputConverter.createArgument(requestDescriptor, argName);
+          listBuilder.add(MethodMetadata.create(function, argument));
+        }
+      } else if (isArg(method.getParameterAnnotations()[i])) {
+        if (javaTypeToScalarMap.containsKey(parameterType)) {
+          String argName = getArgName(method.getParameterAnnotations()[i]);
+          Function<DataFetchingEnvironment, ?> function =
+                  environment -> environment.getArgument(argName);
+          GraphQLArgument argument =
+                  GraphQLArgument.newArgument()
+                          .name(argName)
+                          .type(javaTypeToScalarMap.get(parameterType))
+                          .build();
+          listBuilder.add(MethodMetadata.create(function, argument));
+        } else {
+          throw new RuntimeException("Unknown arg type: " + parameterType.getName());
+        }
+
+      } else if (DataFetchingEnvironment.class.isAssignableFrom(parameterType)) {
+        listBuilder.add(MethodMetadata.create(Functions.identity()));
+      } else {
+        listBuilder.add(MethodMetadata.create(handleParameter(method, i)));
+      }
+    }
+    return listBuilder.build();
+  }
+
+  private static boolean isArg(Annotation[] annotations) {
+    for (Annotation annotation : annotations) {
+      if (annotation.annotationType().isAssignableFrom(Arg.class)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String getArgName(Annotation[] annotations) {
+    for (Annotation annotation : annotations) {
+      if (annotation.annotationType().isAssignableFrom(Arg.class)) {
+        return ((Arg) annotation).value();
+      }
+    }
+    return "input";
+  }
+}

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaDefinitionReader.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaDefinitionReader.java
@@ -26,8 +26,6 @@ import com.google.protobuf.Descriptors.FileDescriptor;
 import com.google.protobuf.Message;
 import graphql.Scalars;
 import graphql.schema.*;
-
-import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -35,10 +33,11 @@ import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
- * Utility class that inspects fields and methods on a "schema definition" object.
- * This results in a {@link SchemaBundle} which can then be turned into a schema.
+ * Utility class that inspects fields and methods on a "schema definition" object. This results in a
+ * {@link SchemaBundle} which can then be turned into a schema.
  *
  * <p>Any public fields of type {@link GraphQLFieldDefinition} annotated with {@link Query} or
  * {@link Mutation} will be added to the top level query or mutation. Fields of type {@link
@@ -94,12 +93,13 @@ public class SchemaDefinitionReader {
     for (Method method : findMethods(moduleClass, Query.class)) {
       Query query = method.getAnnotationsByType(Query.class)[0];
       allQueriesInModule.add(
-              methodToFieldDefinition(schemaDefinition, method, query.value(), query.fullName(), null));
+          methodToFieldDefinition(schemaDefinition, method, query.value(), query.fullName(), null));
     }
     for (Method method : findMethods(moduleClass, Mutation.class)) {
       Mutation mutation = method.getAnnotationsByType(Mutation.class)[0];
       allMutationsInModule.add(
-              methodToFieldDefinition(schemaDefinition, method, mutation.value(), mutation.fullName(), null));
+          methodToFieldDefinition(
+              schemaDefinition, method, mutation.value(), mutation.fullName(), null));
     }
 
     final List<NodeDataFetcher> nodeDataFetchers = new ArrayList<>();
@@ -107,28 +107,28 @@ public class SchemaDefinitionReader {
 
     for (Method method : findMethods(moduleClass, RelayNode.class)) {
       GraphQLFieldDefinition graphQLFieldDefinition =
-              methodToFieldDefinition(schemaDefinition, method, "_NOT_USED_", "_NOT_USED_", null);
+          methodToFieldDefinition(schemaDefinition, method, "_NOT_USED_", "_NOT_USED_", null);
       nodeDataFetchers.add(
-              new NodeDataFetcher(graphQLFieldDefinition.getType().getName()) {
-                @Override
-                public Object apply(String s) {
-                  // TODO: Don't hardcode the arguments structure.
-                  try {
-                    return null;
-                    //                      return graphQLFieldDefinition
-                    //                              .getDataFetcher()
-                    //                              .get(
-                    //
-                    // DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
-                    //
-                    // .arguments(ImmutableMap.of("input", ImmutableMap.of("id",
-                    // s)))
-                    //                                  .build());
-                  } catch (Exception e) {
-                    throw new RuntimeException(e);
-                  }
-                }
-              });
+          new NodeDataFetcher(graphQLFieldDefinition.getType().getName()) {
+            @Override
+            public Object apply(String s) {
+              // TODO: Don't hardcode the arguments structure.
+              try {
+                return null;
+                //                      return graphQLFieldDefinition
+                //                              .getDataFetcher()
+                //                              .get(
+                //
+                // DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                //
+                // .arguments(ImmutableMap.of("input", ImmutableMap.of("id",
+                // s)))
+                //                                  .build());
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            }
+          });
     }
     try {
       for (Method method : findMethods(moduleClass, SchemaModification.class)) {
@@ -137,7 +137,8 @@ public class SchemaDefinitionReader {
         Class<?> typeClass = annotation.onType();
         Descriptor typeDescriptor = (Descriptor) typeClass.getMethod("getDescriptor").invoke(null);
         referencedDescriptors.add(typeDescriptor);
-        schemaModifications.add(methodToTypeModification(schemaDefinition, method, name, typeDescriptor));
+        schemaModifications.add(
+            methodToTypeModification(schemaDefinition, method, name, typeDescriptor));
       }
     } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
       throw new RuntimeException(e);
@@ -161,15 +162,15 @@ public class SchemaDefinitionReader {
       for (Field field : findTypeModificationFields(moduleClass)) {
         field.setAccessible(true);
         schemaBundleBuilder
-                .modificationsBuilder()
-                .add((TypeModification) field.get(schemaDefinition));
+            .modificationsBuilder()
+            .add((TypeModification) field.get(schemaDefinition));
       }
 
       for (Field field : findExtraTypeFields(moduleClass)) {
         field.setAccessible(true);
         schemaBundleBuilder
-                .fileDescriptorsBuilder()
-                .add((FileDescriptor) field.get(schemaDefinition));
+            .fileDescriptorsBuilder()
+            .add((FileDescriptor) field.get(schemaDefinition));
       }
 
       Namespace namespaceAnnotation = findClassAnnotation(moduleClass, Namespace.class);
@@ -181,33 +182,33 @@ public class SchemaDefinitionReader {
         String namespace = namespaceAnnotation.value();
         if (!allQueriesInModule.isEmpty()) {
           schemaBundleBuilder
-                  .queryFieldsBuilder()
-                  .add(
-                          GraphQLFieldDefinition.newFieldDefinition()
-                                  .staticValue("")
-                                  .name(namespace)
-                                  .description(namespace)
-                                  .type(
-                                          GraphQLObjectType.newObject()
-                                                  .name("_QUERY_FIELD_GROUP_" + namespace)
-                                                  .fields(allQueriesInModule)
-                                                  .build())
-                                  .build());
+              .queryFieldsBuilder()
+              .add(
+                  GraphQLFieldDefinition.newFieldDefinition()
+                      .staticValue("")
+                      .name(namespace)
+                      .description(namespace)
+                      .type(
+                          GraphQLObjectType.newObject()
+                              .name("_QUERY_FIELD_GROUP_" + namespace)
+                              .fields(allQueriesInModule)
+                              .build())
+                      .build());
         }
         if (!allMutationsInModule.isEmpty()) {
           schemaBundleBuilder
-                  .mutationFieldsBuilder()
-                  .add(
-                          GraphQLFieldDefinition.newFieldDefinition()
-                                  .staticValue("")
-                                  .name(namespace)
-                                  .description(namespace)
-                                  .type(
-                                          GraphQLObjectType.newObject()
-                                                  .name("_MUTATION_FIELD_GROUP_" + namespace)
-                                                  .fields(allMutationsInModule)
-                                                  .build())
-                                  .build());
+              .mutationFieldsBuilder()
+              .add(
+                  GraphQLFieldDefinition.newFieldDefinition()
+                      .staticValue("")
+                      .name(namespace)
+                      .description(namespace)
+                      .type(
+                          GraphQLObjectType.newObject()
+                              .name("_MUTATION_FIELD_GROUP_" + namespace)
+                              .fields(allMutationsInModule)
+                              .build())
+                      .build());
         }
       }
 
@@ -219,10 +220,9 @@ public class SchemaDefinitionReader {
     }
 
     referencedDescriptors
-            .build()
-            .forEach(
-                    descriptor ->
-                            schemaBundleBuilder.fileDescriptorsBuilder().add(descriptor.getFile()));
+        .build()
+        .forEach(
+            descriptor -> schemaBundleBuilder.fileDescriptorsBuilder().add(descriptor.getFile()));
 
     return schemaBundleBuilder.build();
   }
@@ -237,8 +237,7 @@ public class SchemaDefinitionReader {
    *
    * @param moduleClass
    */
-  private static ImmutableSet<Field> findTypeModificationFields(
-          Class<?> moduleClass) {
+  private static ImmutableSet<Field> findTypeModificationFields(Class<?> moduleClass) {
     return findFields(moduleClass, SchemaModification.class, TypeModification.class);
   }
 
@@ -248,8 +247,7 @@ public class SchemaDefinitionReader {
    *
    * @param moduleClass
    */
-  private static ImmutableSet<Field> findExtraTypeFields(
-          Class<?> moduleClass) {
+  private static ImmutableSet<Field> findExtraTypeFields(Class<?> moduleClass) {
     return findFields(moduleClass, ExtraType.class, FileDescriptor.class);
   }
 
@@ -278,7 +276,7 @@ public class SchemaDefinitionReader {
    * that have the expected type and annotation.
    */
   private static ImmutableSet<Method> findMethods(
-          Class<?> moduleClass, Class<? extends Annotation> targetAnnotation) {
+      Class<?> moduleClass, Class<? extends Annotation> targetAnnotation) {
     Class<?> clazz = moduleClass;
     ImmutableSet.Builder<Method> nodesBuilder = ImmutableSet.builder();
     while (clazz != null && !SchemaDefinitionReader.class.equals(clazz)) {
@@ -297,7 +295,7 @@ public class SchemaDefinitionReader {
    * that have the expected type and annotation.
    */
   private static <T extends Annotation> T findClassAnnotation(
-          Class<?> moduleClass, Class<T> targetAnnotation) {
+      Class<?> moduleClass, Class<T> targetAnnotation) {
     Class<?> clazz = moduleClass;
     while (clazz != null && !SchemaDefinitionReader.class.equals(clazz)) {
       T annotation = clazz.getAnnotation(targetAnnotation);
@@ -314,19 +312,17 @@ public class SchemaDefinitionReader {
    * that have the expected type and annotation.
    */
   private static ImmutableSet<Field> findFields(
-          Class<?> moduleClass,
-          Class<? extends Annotation> targetAnnotation,
-          Class<?> expectedType) {
+      Class<?> moduleClass, Class<? extends Annotation> targetAnnotation, Class<?> expectedType) {
     Class<?> clazz = moduleClass;
     ImmutableSet.Builder<Field> nodesBuilder = ImmutableSet.builder();
     while (clazz != null && !SchemaDefinitionReader.class.equals(clazz)) {
       for (Field method : clazz.getDeclaredFields()) {
         if (method.isAnnotationPresent(targetAnnotation)) {
           Preconditions.checkArgument(
-                  method.getType() == expectedType,
-                  "Field %s should be type %s",
-                  method,
-                  expectedType.getSimpleName());
+              method.getType() == expectedType,
+              "Field %s should be type %s",
+              method,
+              expectedType.getSimpleName());
           nodesBuilder.add(method);
         }
       }
@@ -335,10 +331,9 @@ public class SchemaDefinitionReader {
     return nodesBuilder.build();
   }
 
-  /**
-   * Override to implement additional parametertypes
-   */
-  protected Function<DataFetchingEnvironment, Object> handleParameter(Method method, int parameterIndex) {
+  /** Override to implement additional parametertypes */
+  protected Function<DataFetchingEnvironment, Object> handleParameter(
+      Method method, int parameterIndex) {
     return null;
   }
 
@@ -351,12 +346,12 @@ public class SchemaDefinitionReader {
     abstract GraphQLArgument argument();
 
     static MethodMetadata create(
-            Function<DataFetchingEnvironment, ?> value, GraphQLArgument argument) {
-      return new AutoValue_SchemaDefinition_MethodMetadata(value, argument);
+        Function<DataFetchingEnvironment, ?> value, GraphQLArgument argument) {
+      return new AutoValue_SchemaDefinitionReader_MethodMetadata(value, argument);
     }
 
     static MethodMetadata create(Function<DataFetchingEnvironment, ?> value) {
-      return new AutoValue_SchemaDefinition_MethodMetadata(value, null);
+      return new AutoValue_SchemaDefinitionReader_MethodMetadata(value, null);
     }
 
     Object getParameterValue(DataFetchingEnvironment environment) {
@@ -366,38 +361,42 @@ public class SchemaDefinitionReader {
     boolean hasArgument() {
       return argument() != null;
     }
-
   }
 
   private TypeModification methodToTypeModification(
-          Object module, Method method, String name, Descriptor typeDescriptor) {
-    GraphQLFieldDefinition fieldDef = methodToFieldDefinition(module, method, name, name, typeDescriptor);
+      Object module, Method method, String name, Descriptor typeDescriptor) {
+    GraphQLFieldDefinition fieldDef =
+        methodToFieldDefinition(module, method, name, name, typeDescriptor);
     return Type.find(typeDescriptor).addField(fieldDef);
   }
 
   private GraphQLFieldDefinition methodToFieldDefinition(
-          Object module, Method method, String name, @Nullable String fullName, @Nullable Descriptor descriptor) {
+      Object module,
+      Method method,
+      String name,
+      @Nullable String fullName,
+      @Nullable Descriptor descriptor) {
     method.setAccessible(true);
     try {
       ImmutableList<MethodMetadata> methodParameters = getMethodMetadata(method, descriptor);
       DataFetcher dataFetcher =
-              (DataFetchingEnvironment environment) -> {
-                Object[] methodParameterValues = new Object[methodParameters.size()];
-                for (int i = 0; i < methodParameters.size(); i++) {
-                  methodParameterValues[i] = methodParameters.get(i).getParameterValue(environment);
-                }
-                try {
-                  return method.invoke(module, methodParameterValues);
-                } catch (InvocationTargetException e) {
-                  Throwable cause = e.getCause();
-                  if (cause instanceof RuntimeException) {
-                    throw (RuntimeException) cause;
-                  }
-                  throw new RuntimeException(cause);
-                } catch (Exception e) {
-                  throw new RuntimeException(e);
-                }
-              };
+          (DataFetchingEnvironment environment) -> {
+            Object[] methodParameterValues = new Object[methodParameters.size()];
+            for (int i = 0; i < methodParameters.size(); i++) {
+              methodParameterValues[i] = methodParameters.get(i).getParameterValue(environment);
+            }
+            try {
+              return method.invoke(module, methodParameterValues);
+            } catch (InvocationTargetException e) {
+              Throwable cause = e.getCause();
+              if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+              }
+              throw new RuntimeException(cause);
+            } catch (Exception e) {
+              throw new RuntimeException(e);
+            }
+          };
 
       GraphQLOutputType returnType = getReturnType(method);
 
@@ -419,15 +418,15 @@ public class SchemaDefinitionReader {
   }
 
   ImmutableMap<java.lang.reflect.Type, GraphQLScalarType> javaTypeToScalarMap =
-          ImmutableMap.of(
-                  String.class, Scalars.GraphQLString,
-                  Integer.class, Scalars.GraphQLInt,
-                  Boolean.class, Scalars.GraphQLBoolean,
-                  Long.class, Scalars.GraphQLLong,
-                  Float.class, Scalars.GraphQLFloat);
+      ImmutableMap.of(
+          String.class, Scalars.GraphQLString,
+          Integer.class, Scalars.GraphQLInt,
+          Boolean.class, Scalars.GraphQLBoolean,
+          Long.class, Scalars.GraphQLLong,
+          Float.class, Scalars.GraphQLFloat);
 
   private GraphQLOutputType getReturnType(Method method)
-          throws IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+      throws IllegalAccessException, InvocationTargetException, NoSuchMethodException {
     // Currently it's assumed the response is of type Message, ListenableFuture<? extends
     // Message>, ImmutableList<Message>, ListenableFuture<ImmutableList<? extend Message>>, oe
     // any Scalar type.
@@ -439,7 +438,7 @@ public class SchemaDefinitionReader {
         @SuppressWarnings("unchecked")
         Class<? extends Message> responseClass = (Class<? extends Message>) method.getReturnType();
         Descriptor responseDescriptor =
-                (Descriptor) responseClass.getMethod("getDescriptor").invoke(null);
+            (Descriptor) responseClass.getMethod("getDescriptor").invoke(null);
         referencedDescriptors.add(responseDescriptor);
         return ProtoToGql.getReference(responseDescriptor);
       }
@@ -456,11 +455,11 @@ public class SchemaDefinitionReader {
     java.lang.reflect.Type genericTypeValue = genericReturnType.getActualTypeArguments()[0];
     if (genericTypeValue instanceof ParameterizedType) {
       java.lang.reflect.Type listElType =
-              ((ParameterizedType) genericTypeValue).getActualTypeArguments()[0];
+          ((ParameterizedType) genericTypeValue).getActualTypeArguments()[0];
       @SuppressWarnings("unchecked")
       Class<? extends Message> responseClass = (Class<? extends Message>) listElType;
       Descriptor responseDescriptor =
-              (Descriptor) responseClass.getMethod("getDescriptor").invoke(null);
+          (Descriptor) responseClass.getMethod("getDescriptor").invoke(null);
       referencedDescriptors.add(responseDescriptor);
       return new GraphQLList(new GraphQLNonNull(ProtoToGql.getReference(responseDescriptor)));
     }
@@ -470,7 +469,7 @@ public class SchemaDefinitionReader {
       @SuppressWarnings("unchecked")
       Class<? extends Message> responseClass = (Class<? extends Message>) genericTypeValue;
       Descriptor responseDescriptor =
-              (Descriptor) responseClass.getMethod("getDescriptor").invoke(null);
+          (Descriptor) responseClass.getMethod("getDescriptor").invoke(null);
       referencedDescriptors.add(responseDescriptor);
       return new GraphQLList(new GraphQLNonNull(ProtoToGql.getReference(responseDescriptor)));
     }
@@ -478,16 +477,16 @@ public class SchemaDefinitionReader {
     // ListenableFuture<? extends Message>
     @SuppressWarnings("unchecked")
     Class<? extends Message> responseClass =
-            (Class<? extends Message>) genericReturnType.getActualTypeArguments()[0];
+        (Class<? extends Message>) genericReturnType.getActualTypeArguments()[0];
     Descriptor responseDescriptor =
-            (Descriptor) responseClass.getMethod("getDescriptor").invoke(null);
+        (Descriptor) responseClass.getMethod("getDescriptor").invoke(null);
     referencedDescriptors.add(responseDescriptor);
     return ProtoToGql.getReference(responseDescriptor);
   }
 
   private ImmutableList<MethodMetadata> getMethodMetadata(
-          Method method, @Nullable Descriptor sourceDescriptor)
-          throws IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+      Method method, @Nullable Descriptor sourceDescriptor)
+      throws IllegalAccessException, InvocationTargetException, NoSuchMethodException {
     final Class<?>[] parameterTypes = method.getParameterTypes();
 
     ImmutableList.Builder<MethodMetadata> listBuilder = ImmutableList.builder();
@@ -498,25 +497,25 @@ public class SchemaDefinitionReader {
         @SuppressWarnings("unchecked")
         Class<? extends Message> requestClass = (Class<? extends Message>) parameterType;
         Descriptor requestDescriptor =
-                (Descriptor) requestClass.getMethod("getDescriptor").invoke(null);
+            (Descriptor) requestClass.getMethod("getDescriptor").invoke(null);
         if (sourceDescriptor != null
-                && requestDescriptor.getFullName().equals(sourceDescriptor.getFullName())) {
+            && requestDescriptor.getFullName().equals(sourceDescriptor.getFullName())) {
           Function<DataFetchingEnvironment, ?> function = environment -> environment.getSource();
           listBuilder.add(MethodMetadata.create(function));
         } else {
           GqlInputConverter inputConverter =
-                  GqlInputConverter.newBuilder().add(requestDescriptor.getFile()).build();
+              GqlInputConverter.newBuilder().add(requestDescriptor.getFile()).build();
           addExtraType(requestDescriptor);
           Message message =
-                  ((Message.Builder) requestClass.getMethod("newBuilder").invoke(null)).build();
+              ((Message.Builder) requestClass.getMethod("newBuilder").invoke(null)).build();
           String argName = getArgName(method.getParameterAnnotations()[i]);
           Function<DataFetchingEnvironment, ?> function =
-                  environment -> {
-                    Message req =
-                            inputConverter.createProtoBuf(
-                                    requestDescriptor, message.toBuilder(), environment.getArgument(argName));
-                    return req;
-                  };
+              environment -> {
+                Message req =
+                    inputConverter.createProtoBuf(
+                        requestDescriptor, message.toBuilder(), environment.getArgument(argName));
+                return req;
+              };
           GraphQLArgument argument = GqlInputConverter.createArgument(requestDescriptor, argName);
           listBuilder.add(MethodMetadata.create(function, argument));
         }
@@ -524,12 +523,12 @@ public class SchemaDefinitionReader {
         if (javaTypeToScalarMap.containsKey(parameterType)) {
           String argName = getArgName(method.getParameterAnnotations()[i]);
           Function<DataFetchingEnvironment, ?> function =
-                  environment -> environment.getArgument(argName);
+              environment -> environment.getArgument(argName);
           GraphQLArgument argument =
-                  GraphQLArgument.newArgument()
-                          .name(argName)
-                          .type(javaTypeToScalarMap.get(parameterType))
-                          .build();
+              GraphQLArgument.newArgument()
+                  .name(argName)
+                  .type(javaTypeToScalarMap.get(parameterType))
+                  .build();
           listBuilder.add(MethodMetadata.create(function, argument));
         } else {
           throw new RuntimeException("Unknown arg type: " + parameterType.getName());

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaModule.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaModule.java
@@ -14,13 +14,8 @@
 
 package com.google.api.graphql.rejoiner;
 
-import com.google.auto.value.AutoValue;
 import com.google.common.base.Function;
-import com.google.common.base.Functions;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
@@ -28,27 +23,13 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FileDescriptor;
-import com.google.protobuf.Message;
-import graphql.Scalars;
-import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLFieldDefinition;
-import graphql.schema.GraphQLList;
-import graphql.schema.GraphQLNonNull;
-import graphql.schema.GraphQLObjectType;
-import graphql.schema.GraphQLOutputType;
-import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLTypeReference;
+
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
-import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nullable;
-import javax.inject.Provider;
 
 /**
  * Module for registering parts of a {@link graphql.schema.GraphQLSchema}.
@@ -62,9 +43,49 @@ import javax.inject.Provider;
  */
 public abstract class SchemaModule extends AbstractModule {
 
-  private final ImmutableSet.Builder<Descriptor> referencedDescriptors = ImmutableSet.builder();
-  private final List<GraphQLFieldDefinition> allQueriesInModule = new ArrayList<>();
-  private final List<GraphQLFieldDefinition> allMutationsInModule = new ArrayList<>();
+  private final Object schemaDefinition;
+
+  /**
+   * Uses the fields and methods on the given schema definition.
+   */
+  public SchemaModule(Object schemaDefinition) {
+    this.schemaDefinition = schemaDefinition;
+  }
+
+  /**
+   * Uses the fields and methods on the module itself.
+   */
+  public SchemaModule() {
+    schemaDefinition = this;
+  }
+
+  private final SchemaDefinitionReader definition = new SchemaDefinitionReader() {
+    @Override
+    protected ImmutableList<GraphQLFieldDefinition> extraMutations() {
+      return SchemaModule.this.extraMutations();
+    }
+
+    @Override
+    protected Function<DataFetchingEnvironment, Object> handleParameter(Method method, int parameterIndex) {
+      Annotation[] annotations = method.getParameterAnnotations()[parameterIndex];
+      Annotation qualifier = null;
+      for (Annotation annotation : annotations) {
+        if (com.google.inject.internal.Annotations.isBindingAnnotation(
+                annotation.annotationType())) {
+          qualifier = annotation;
+        }
+      }
+      final java.lang.reflect.Type[] genericParameterTypes = method.getGenericParameterTypes();
+      Key<?> key =
+              qualifier == null
+                      ? Key.get(genericParameterTypes[parameterIndex])
+                      : Key.get(genericParameterTypes[parameterIndex], qualifier);
+
+      final com.google.inject.Provider<?> provider = binder().getProvider(key);
+      return (ignored) -> provider;
+    }
+
+  };
 
   /**
    * Returns a reference to the GraphQL type corresponding to the supplied proto.
@@ -72,13 +93,11 @@ public abstract class SchemaModule extends AbstractModule {
    * <p>All types in the proto are made available to be included in the GraphQL schema.
    */
   protected final GraphQLTypeReference getTypeReference(Descriptor descriptor) {
-    referencedDescriptors.add(descriptor);
-    return ProtoToGql.getReference(descriptor);
+    return definition.getTypeReference(descriptor);
   }
 
   protected final GraphQLTypeReference getInputTypeReference(Descriptor descriptor) {
-    referencedDescriptors.add(descriptor);
-    return new GraphQLTypeReference(GqlInputConverter.getReferenceName(descriptor));
+    return definition.getInputTypeReference(descriptor);
   }
 
   protected ImmutableList<GraphQLFieldDefinition> extraMutations() {
@@ -86,516 +105,43 @@ public abstract class SchemaModule extends AbstractModule {
   }
 
   protected void addQuery(GraphQLFieldDefinition query) {
-    allQueriesInModule.add(query);
+    definition.addQuery(query);
   }
 
   protected void addMutation(GraphQLFieldDefinition mutation) {
-    allMutationsInModule.add(mutation);
+    definition.addMutation(mutation);
   }
 
   protected void addQueryList(List<GraphQLFieldDefinition> queries) {
-    allQueriesInModule.addAll(queries);
+    definition.addQueryList(queries);
   }
 
   protected void addMutationList(List<GraphQLFieldDefinition> mutations) {
-    allMutationsInModule.addAll(mutations);
+    definition.addMutationList(mutations);
   }
 
-  protected void configureSchema() {}
+  protected void configureSchema() {
+  }
 
   @Override
   protected final void configure() {
-    Multibinder<SchemaBundle> schemaBundleProviders =
-        Multibinder.newSetBinder(
-            binder(), new TypeLiteral<SchemaBundle>() {}, Annotations.SchemaBundles.class);
+    Multibinder<SchemaBundle> schemaBundleProviders = Multibinder.newSetBinder(
+            binder(),
+            new TypeLiteral<SchemaBundle>() {
+            },
+            Annotations.SchemaBundles.class);
 
-    final Class<? extends SchemaModule> moduleClass = getClass();
-
-    for (Method method : findMethods(moduleClass, Query.class)) {
-      Query query = method.getAnnotationsByType(Query.class)[0];
-      allQueriesInModule.add(
-          methodToFieldDefinition(method, query.value(), query.fullName(), null));
-    }
-    for (Method method : findMethods(moduleClass, Mutation.class)) {
-      Mutation mutation = method.getAnnotationsByType(Mutation.class)[0];
-      allMutationsInModule.add(
-          methodToFieldDefinition(method, mutation.value(), mutation.fullName(), null));
-    }
-
-    final List<NodeDataFetcher> nodeDataFetchers = new ArrayList<>();
-    final List<TypeModification> schemaModifications = new ArrayList<>();
-
-    for (Method method : findMethods(moduleClass, RelayNode.class)) {
-      GraphQLFieldDefinition graphQLFieldDefinition =
-          methodToFieldDefinition(method, "_NOT_USED_", "_NOT_USED_", null);
-      nodeDataFetchers.add(
-          new NodeDataFetcher(graphQLFieldDefinition.getType().getName()) {
-            @Override
-            public Object apply(String s) {
-              // TODO: Don't hardcode the arguments structure.
-              try {
-                return null;
-                //                      return graphQLFieldDefinition
-                //                              .getDataFetcher()
-                //                              .get(
-                //
-                // DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
-                //
-                // .arguments(ImmutableMap.of("input", ImmutableMap.of("id",
-                // s)))
-                //                                  .build());
-              } catch (Exception e) {
-                throw new RuntimeException(e);
-              }
-            }
-          });
-    }
-    try {
-      for (Method method : findMethods(moduleClass, SchemaModification.class)) {
-        SchemaModification annotation = method.getAnnotationsByType(SchemaModification.class)[0];
-        String name = annotation.addField();
-        Class<?> typeClass = annotation.onType();
-        Descriptor typeDescriptor = (Descriptor) typeClass.getMethod("getDescriptor").invoke(null);
-        referencedDescriptors.add(typeDescriptor);
-        schemaModifications.add(methodToTypeModification(method, name, typeDescriptor));
-      }
-    } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-      throw new RuntimeException(e);
-    }
-
-    schemaBundleProviders
-        .addBinding()
-        .toProvider(
+    schemaBundleProviders.addBinding().toProvider(
             () -> {
               configureSchema();
-              SchemaBundle.Builder schemaBundleBuilder = SchemaBundle.builder();
-
-              allMutationsInModule.addAll(extraMutations());
-
-              try {
-                for (Field field : findQueryFields(moduleClass)) {
-                  field.setAccessible(true);
-                  allQueriesInModule.add((GraphQLFieldDefinition) field.get(this));
-                }
-
-                for (Field field : findMutationFields(moduleClass)) {
-                  field.setAccessible(true);
-                  allMutationsInModule.add((GraphQLFieldDefinition) field.get(this));
-                }
-
-                for (Field field : findTypeModificationFields(moduleClass)) {
-                  field.setAccessible(true);
-                  schemaBundleBuilder
-                      .modificationsBuilder()
-                      .add((TypeModification) field.get(this));
-                }
-
-                for (Field field : findExtraTypeFields(moduleClass)) {
-                  field.setAccessible(true);
-                  schemaBundleBuilder
-                      .fileDescriptorsBuilder()
-                      .add((FileDescriptor) field.get(this));
-                }
-
-                Namespace namespaceAnnotation = findClassAnnotation(moduleClass, Namespace.class);
-
-                if (namespaceAnnotation == null) {
-                  schemaBundleBuilder.mutationFieldsBuilder().addAll(allMutationsInModule);
-                  schemaBundleBuilder.queryFieldsBuilder().addAll(allQueriesInModule);
-                } else {
-                  String namespace = namespaceAnnotation.value();
-                  if (!allQueriesInModule.isEmpty()) {
-                    schemaBundleBuilder
-                        .queryFieldsBuilder()
-                        .add(
-                            GraphQLFieldDefinition.newFieldDefinition()
-                                .staticValue("")
-                                .name(namespace)
-                                .description(namespace)
-                                .type(
-                                    GraphQLObjectType.newObject()
-                                        .name("_QUERY_FIELD_GROUP_" + namespace)
-                                        .fields(allQueriesInModule)
-                                        .build())
-                                .build());
-                  }
-                  if (!allMutationsInModule.isEmpty()) {
-                    schemaBundleBuilder
-                        .mutationFieldsBuilder()
-                        .add(
-                            GraphQLFieldDefinition.newFieldDefinition()
-                                .staticValue("")
-                                .name(namespace)
-                                .description(namespace)
-                                .type(
-                                    GraphQLObjectType.newObject()
-                                        .name("_MUTATION_FIELD_GROUP_" + namespace)
-                                        .fields(allMutationsInModule)
-                                        .build())
-                                .build());
-                  }
-                }
-
-                schemaBundleBuilder.nodeDataFetchersBuilder().addAll(nodeDataFetchers);
-                schemaBundleBuilder.modificationsBuilder().addAll(schemaModifications);
-
-              } catch (IllegalAccessException e) {
-                throw new RuntimeException(e);
-              }
-
-              referencedDescriptors
-                  .build()
-                  .forEach(
-                      descriptor ->
-                          schemaBundleBuilder.fileDescriptorsBuilder().add(descriptor.getFile()));
-
-              return schemaBundleBuilder.build();
+              return definition.createBundle(schemaDefinition);
             });
 
     requestInjection(this);
   }
 
   void addExtraType(Descriptors.Descriptor descriptor) {
-    referencedDescriptors.add(descriptor);
+    definition.addExtraType(descriptor);
   }
 
-  /**
-   * Returns an {@link ImmutableSet} of all the methods in {@code moduleClass} or its super classes
-   * that are annotated with {@link Query}.
-   */
-  private static ImmutableSet<Field> findTypeModificationFields(
-      Class<? extends SchemaModule> moduleClass) {
-    return findFields(moduleClass, SchemaModification.class, TypeModification.class);
-  }
-
-  /**
-   * Returns an {@link ImmutableSet} of all the methods in {@code moduleClass} or its super classes
-   * that are annotated with {@link Query}.
-   */
-  private static ImmutableSet<Field> findExtraTypeFields(
-      Class<? extends SchemaModule> moduleClass) {
-    return findFields(moduleClass, ExtraType.class, FileDescriptor.class);
-  }
-
-  /**
-   * Returns an {@link ImmutableSet} of all the methods in {@code moduleClass} or its super classes
-   * that are annotated with {@link Query}.
-   */
-  private static ImmutableSet<Field> findMutationFields(Class<? extends SchemaModule> moduleClass) {
-    return findFields(moduleClass, Mutation.class, GraphQLFieldDefinition.class);
-  }
-
-  /**
-   * Returns an {@link ImmutableSet} of all the methods in {@code moduleClass} or its super classes
-   * that are annotated with {@link Query}.
-   */
-  private static ImmutableSet<Field> findQueryFields(Class<? extends SchemaModule> moduleClass) {
-    return findFields(moduleClass, Query.class, GraphQLFieldDefinition.class);
-  }
-
-  /**
-   * Returns an {@link ImmutableSet} of all the methods in {@code moduleClass} or its super classes
-   * that have the expected type and annotation.
-   */
-  private static ImmutableSet<Method> findMethods(
-      Class<? extends SchemaModule> moduleClass, Class<? extends Annotation> targetAnnotation) {
-    Class<?> clazz = moduleClass;
-    ImmutableSet.Builder<Method> nodesBuilder = ImmutableSet.builder();
-    while (clazz != null && !SchemaModule.class.equals(clazz)) {
-      for (Method method : clazz.getDeclaredMethods()) {
-        if (method.isAnnotationPresent(targetAnnotation)) {
-          nodesBuilder.add(method);
-        }
-      }
-      clazz = clazz.getSuperclass();
-    }
-    return nodesBuilder.build();
-  }
-
-  /**
-   * Returns an {@link ImmutableSet} of all the methods in {@code moduleClass} or its super classes
-   * that have the expected type and annotation.
-   */
-  private static <T extends Annotation> T findClassAnnotation(
-      Class<? extends SchemaModule> moduleClass, Class<T> targetAnnotation) {
-    Class<?> clazz = moduleClass;
-    while (clazz != null && !SchemaModule.class.equals(clazz)) {
-      T annotation = clazz.getAnnotation(targetAnnotation);
-      if (annotation != null) {
-        return annotation;
-      }
-      clazz = clazz.getSuperclass();
-    }
-    return null;
-  }
-
-  /**
-   * Returns an {@link ImmutableSet} of all the fields in {@code moduleClass} or its super classes
-   * that have the expected type and annotation.
-   */
-  private static ImmutableSet<Field> findFields(
-      Class<? extends SchemaModule> moduleClass,
-      Class<? extends Annotation> targetAnnotation,
-      Class<?> expectedType) {
-    Class<?> clazz = moduleClass;
-    ImmutableSet.Builder<Field> nodesBuilder = ImmutableSet.builder();
-    while (clazz != null && !SchemaModule.class.equals(clazz)) {
-      for (Field method : clazz.getDeclaredFields()) {
-        if (method.isAnnotationPresent(targetAnnotation)) {
-          Preconditions.checkArgument(
-              method.getType() == expectedType,
-              "Field %s should be type %s",
-              method,
-              expectedType.getSimpleName());
-          nodesBuilder.add(method);
-        }
-      }
-      clazz = clazz.getSuperclass();
-    }
-    return nodesBuilder.build();
-  }
-
-  @AutoValue
-  abstract static class MethodMetadata {
-    @Nullable
-    abstract Provider<?> provider();
-
-    @Nullable
-    abstract Function<DataFetchingEnvironment, ?> function();
-
-    @Nullable
-    abstract GraphQLArgument argument();
-
-    static MethodMetadata create(Provider<?> value) {
-      return new AutoValue_SchemaModule_MethodMetadata(value, null, null);
-    }
-
-    static MethodMetadata create(
-        Function<DataFetchingEnvironment, ?> value, GraphQLArgument argument) {
-      return new AutoValue_SchemaModule_MethodMetadata(null, value, argument);
-    }
-
-    static MethodMetadata create(Function<DataFetchingEnvironment, ?> value) {
-      return new AutoValue_SchemaModule_MethodMetadata(null, value, null);
-    }
-
-    Object getParameterValue(DataFetchingEnvironment environment) {
-      if (provider() != null) {
-        return provider().get();
-      } else {
-        return function().apply(environment);
-      }
-    }
-
-    boolean hasArgument() {
-      return argument() != null;
-    }
-  }
-
-  private TypeModification methodToTypeModification(
-      Method method, String name, Descriptor typeDescriptor) {
-    GraphQLFieldDefinition fieldDef = methodToFieldDefinition(method, name, name, typeDescriptor);
-    return Type.find(typeDescriptor).addField(fieldDef);
-  }
-
-  private GraphQLFieldDefinition methodToFieldDefinition(
-      Method method, String name, @Nullable String fullName, @Nullable Descriptor descriptor) {
-    method.setAccessible(true);
-    try {
-      ImmutableList<MethodMetadata> methodParameters = getMethodMetadata(method, descriptor);
-      DataFetcher dataFetcher =
-          (DataFetchingEnvironment environment) -> {
-            Object[] methodParameterValues = new Object[methodParameters.size()];
-            for (int i = 0; i < methodParameters.size(); i++) {
-              methodParameterValues[i] = methodParameters.get(i).getParameterValue(environment);
-            }
-            try {
-              return method.invoke(this, methodParameterValues);
-            } catch (InvocationTargetException e) {
-              Throwable cause = e.getCause();
-              if (cause instanceof RuntimeException) {
-                throw (RuntimeException) cause;
-              }
-              throw new RuntimeException(cause);
-            } catch (Exception e) {
-              throw new RuntimeException(e);
-            }
-          };
-
-      GraphQLOutputType returnType = getReturnType(method);
-
-      // Create GraphQL Field Definition
-      GraphQLFieldDefinition.Builder fieldDef = GraphQLFieldDefinition.newFieldDefinition();
-      fieldDef.type(returnType);
-      fieldDef.name(name);
-      fieldDef.description(DescriptorSet.COMMENTS.get(fullName));
-      for (MethodMetadata methodMetadata : methodParameters) {
-        if (methodMetadata.hasArgument()) {
-          fieldDef.argument(methodMetadata.argument());
-        }
-      }
-      fieldDef.dataFetcher(dataFetcher);
-      return fieldDef.build();
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  ImmutableMap<java.lang.reflect.Type, GraphQLScalarType> javaTypeToScalarMap =
-      ImmutableMap.of(
-          String.class, Scalars.GraphQLString,
-          Integer.class, Scalars.GraphQLInt,
-          Boolean.class, Scalars.GraphQLBoolean,
-          Long.class, Scalars.GraphQLLong,
-          Float.class, Scalars.GraphQLFloat);
-
-  private GraphQLOutputType getReturnType(Method method)
-      throws IllegalAccessException, InvocationTargetException, NoSuchMethodException {
-    // Currently it's assumed the response is of type Message, ListenableFuture<? extends
-    // Message>, ImmutableList<Message>, ListenableFuture<ImmutableList<? extend Message>>, oe
-    // any Scalar type.
-
-    // Assume Message or Scalar
-    if (!(method.getGenericReturnType() instanceof ParameterizedType)) {
-      Class<?> returnType = method.getReturnType();
-      if (Message.class.isAssignableFrom(returnType)) {
-        @SuppressWarnings("unchecked")
-        Class<? extends Message> responseClass = (Class<? extends Message>) method.getReturnType();
-        Descriptor responseDescriptor =
-            (Descriptor) responseClass.getMethod("getDescriptor").invoke(null);
-        referencedDescriptors.add(responseDescriptor);
-        return ProtoToGql.getReference(responseDescriptor);
-      }
-      if (javaTypeToScalarMap.containsKey(returnType)) {
-        return javaTypeToScalarMap.get(returnType);
-      }
-      throw new RuntimeException("Unknown scalar type: " + returnType.getTypeName());
-    }
-
-    ParameterizedType genericReturnType = (ParameterizedType) method.getGenericReturnType();
-    // TODO: handle collections of Java Scalars
-
-    // Assume ListenableFuture<ImmutableList<? extends Message>>
-    java.lang.reflect.Type genericTypeValue = genericReturnType.getActualTypeArguments()[0];
-    if (genericTypeValue instanceof ParameterizedType) {
-      java.lang.reflect.Type listElType =
-          ((ParameterizedType) genericTypeValue).getActualTypeArguments()[0];
-      @SuppressWarnings("unchecked")
-      Class<? extends Message> responseClass = (Class<? extends Message>) listElType;
-      Descriptor responseDescriptor =
-          (Descriptor) responseClass.getMethod("getDescriptor").invoke(null);
-      referencedDescriptors.add(responseDescriptor);
-      return new GraphQLList(new GraphQLNonNull(ProtoToGql.getReference(responseDescriptor)));
-    }
-
-    // ImmutableList<? extends Message>
-    if (ImmutableList.class.isAssignableFrom((Class<?>) genericReturnType.getRawType())) {
-      @SuppressWarnings("unchecked")
-      Class<? extends Message> responseClass = (Class<? extends Message>) genericTypeValue;
-      Descriptor responseDescriptor =
-          (Descriptor) responseClass.getMethod("getDescriptor").invoke(null);
-      referencedDescriptors.add(responseDescriptor);
-      return new GraphQLList(new GraphQLNonNull(ProtoToGql.getReference(responseDescriptor)));
-    }
-
-    // ListenableFuture<? extends Message>
-    @SuppressWarnings("unchecked")
-    Class<? extends Message> responseClass =
-        (Class<? extends Message>) genericReturnType.getActualTypeArguments()[0];
-    Descriptor responseDescriptor =
-        (Descriptor) responseClass.getMethod("getDescriptor").invoke(null);
-    referencedDescriptors.add(responseDescriptor);
-    return ProtoToGql.getReference(responseDescriptor);
-  }
-
-  private ImmutableList<MethodMetadata> getMethodMetadata(
-      Method method, @Nullable Descriptor sourceDescriptor)
-      throws IllegalAccessException, InvocationTargetException, NoSuchMethodException {
-    final Class<?>[] parameterTypes = method.getParameterTypes();
-    final java.lang.reflect.Type[] genericParameterTypes = method.getGenericParameterTypes();
-
-    ImmutableList.Builder<MethodMetadata> listBuilder = ImmutableList.builder();
-    for (int i = 0; i < parameterTypes.length; i++) {
-
-      Class<?> parameterType = parameterTypes[i];
-      if (Message.class.isAssignableFrom(parameterType)) {
-        @SuppressWarnings("unchecked")
-        Class<? extends Message> requestClass = (Class<? extends Message>) parameterType;
-        Descriptor requestDescriptor =
-            (Descriptor) requestClass.getMethod("getDescriptor").invoke(null);
-        if (sourceDescriptor != null
-            && requestDescriptor.getFullName().equals(sourceDescriptor.getFullName())) {
-          Function<DataFetchingEnvironment, ?> function = environment -> environment.getSource();
-          listBuilder.add(MethodMetadata.create(function));
-        } else {
-          GqlInputConverter inputConverter =
-              GqlInputConverter.newBuilder().add(requestDescriptor.getFile()).build();
-          addExtraType(requestDescriptor);
-          Message message =
-              ((Message.Builder) requestClass.getMethod("newBuilder").invoke(null)).build();
-          String argName = getArgName(method.getParameterAnnotations()[i]);
-          Function<DataFetchingEnvironment, ?> function =
-              environment -> {
-                Message req =
-                    inputConverter.createProtoBuf(
-                        requestDescriptor, message.toBuilder(), environment.getArgument(argName));
-                return req;
-              };
-          GraphQLArgument argument = GqlInputConverter.createArgument(requestDescriptor, argName);
-          listBuilder.add(MethodMetadata.create(function, argument));
-        }
-      } else if (isArg(method.getParameterAnnotations()[i])) {
-        if (javaTypeToScalarMap.containsKey(parameterType)) {
-          String argName = getArgName(method.getParameterAnnotations()[i]);
-          Function<DataFetchingEnvironment, ?> function =
-              environment -> environment.getArgument(argName);
-          GraphQLArgument argument =
-              GraphQLArgument.newArgument()
-                  .name(argName)
-                  .type(javaTypeToScalarMap.get(parameterType))
-                  .build();
-          listBuilder.add(MethodMetadata.create(function, argument));
-        } else {
-          throw new RuntimeException("Unknown arg type: " + parameterType.getName());
-        }
-
-      } else if (DataFetchingEnvironment.class.isAssignableFrom(parameterType)) {
-        listBuilder.add(MethodMetadata.create(Functions.identity()));
-      } else {
-        Annotation[] annotations = method.getParameterAnnotations()[i];
-        Annotation qualifier = null;
-        for (Annotation annotation : annotations) {
-          if (com.google.inject.internal.Annotations.isBindingAnnotation(
-              annotation.annotationType())) {
-            qualifier = annotation;
-          }
-        }
-        Key<?> key =
-            qualifier == null
-                ? Key.get(genericParameterTypes[i])
-                : Key.get(genericParameterTypes[i], qualifier);
-
-        listBuilder.add(MethodMetadata.create(binder().getProvider(key)));
-      }
-    }
-    return listBuilder.build();
-  }
-
-  private static boolean isArg(Annotation[] annotations) {
-    for (Annotation annotation : annotations) {
-      if (annotation.annotationType().isAssignableFrom(Arg.class)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private static String getArgName(Annotation[] annotations) {
-    for (Annotation annotation : annotations) {
-      if (annotation.annotationType().isAssignableFrom(Arg.class)) {
-        return ((Arg) annotation).value();
-      }
-    }
-    return "input";
-  }
 }

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaModule.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaModule.java
@@ -26,7 +26,6 @@ import com.google.protobuf.Descriptors.FileDescriptor;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLTypeReference;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.List;
@@ -45,47 +44,44 @@ public abstract class SchemaModule extends AbstractModule {
 
   private final Object schemaDefinition;
 
-  /**
-   * Uses the fields and methods on the given schema definition.
-   */
+  /** Uses the fields and methods on the given schema definition. */
   public SchemaModule(Object schemaDefinition) {
     this.schemaDefinition = schemaDefinition;
   }
 
-  /**
-   * Uses the fields and methods on the module itself.
-   */
+  /** Uses the fields and methods on the module itself. */
   public SchemaModule() {
     schemaDefinition = this;
   }
 
-  private final SchemaDefinitionReader definition = new SchemaDefinitionReader() {
-    @Override
-    protected ImmutableList<GraphQLFieldDefinition> extraMutations() {
-      return SchemaModule.this.extraMutations();
-    }
-
-    @Override
-    protected Function<DataFetchingEnvironment, Object> handleParameter(Method method, int parameterIndex) {
-      Annotation[] annotations = method.getParameterAnnotations()[parameterIndex];
-      Annotation qualifier = null;
-      for (Annotation annotation : annotations) {
-        if (com.google.inject.internal.Annotations.isBindingAnnotation(
-                annotation.annotationType())) {
-          qualifier = annotation;
+  private final SchemaDefinitionReader definition =
+      new SchemaDefinitionReader() {
+        @Override
+        protected ImmutableList<GraphQLFieldDefinition> extraMutations() {
+          return SchemaModule.this.extraMutations();
         }
-      }
-      final java.lang.reflect.Type[] genericParameterTypes = method.getGenericParameterTypes();
-      Key<?> key =
+
+        @Override
+        protected Function<DataFetchingEnvironment, Object> handleParameter(
+            Method method, int parameterIndex) {
+          Annotation[] annotations = method.getParameterAnnotations()[parameterIndex];
+          Annotation qualifier = null;
+          for (Annotation annotation : annotations) {
+            if (com.google.inject.internal.Annotations.isBindingAnnotation(
+                annotation.annotationType())) {
+              qualifier = annotation;
+            }
+          }
+          final java.lang.reflect.Type[] genericParameterTypes = method.getGenericParameterTypes();
+          Key<?> key =
               qualifier == null
-                      ? Key.get(genericParameterTypes[parameterIndex])
-                      : Key.get(genericParameterTypes[parameterIndex], qualifier);
+                  ? Key.get(genericParameterTypes[parameterIndex])
+                  : Key.get(genericParameterTypes[parameterIndex], qualifier);
 
-      final com.google.inject.Provider<?> provider = binder().getProvider(key);
-      return (ignored) -> provider;
-    }
-
-  };
+          final com.google.inject.Provider<?> provider = binder().getProvider(key);
+          return (ignored) -> provider;
+        }
+      };
 
   /**
    * Returns a reference to the GraphQL type corresponding to the supplied proto.
@@ -120,18 +116,17 @@ public abstract class SchemaModule extends AbstractModule {
     definition.addMutationList(mutations);
   }
 
-  protected void configureSchema() {
-  }
+  protected void configureSchema() {}
 
   @Override
   protected final void configure() {
-    Multibinder<SchemaBundle> schemaBundleProviders = Multibinder.newSetBinder(
-            binder(),
-            new TypeLiteral<SchemaBundle>() {
-            },
-            Annotations.SchemaBundles.class);
+    Multibinder<SchemaBundle> schemaBundleProviders =
+        Multibinder.newSetBinder(
+            binder(), new TypeLiteral<SchemaBundle>() {}, Annotations.SchemaBundles.class);
 
-    schemaBundleProviders.addBinding().toProvider(
+    schemaBundleProviders
+        .addBinding()
+        .toProvider(
             () -> {
               configureSchema();
               return definition.createBundle(schemaDefinition);
@@ -143,5 +138,4 @@ public abstract class SchemaModule extends AbstractModule {
   void addExtraType(Descriptors.Descriptor descriptor) {
     definition.addExtraType(descriptor);
   }
-
 }

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaProviderModule.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/SchemaProviderModule.java
@@ -17,14 +17,11 @@ package com.google.api.graphql.rejoiner;
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
 import graphql.schema.GraphQLSchema;
-
+import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Provider;
-import java.util.Set;
 
-/**
- * Provides a {@link GraphQLSchema} by combining fields from all SchemaModules.
- */
+/** Provides a {@link GraphQLSchema} by combining fields from all SchemaModules. */
 public final class SchemaProviderModule extends AbstractModule {
 
   static class SchemaImpl implements Provider<GraphQLSchema> {
@@ -46,8 +43,8 @@ public final class SchemaProviderModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(GraphQLSchema.class)
-            .annotatedWith(Schema.class)
-            .toProvider(SchemaImpl.class)
-            .in(Singleton.class);
+        .annotatedWith(Schema.class)
+        .toProvider(SchemaImpl.class)
+        .in(Singleton.class);
   }
 }

--- a/rejoiner/src/test/java/com/google/api/graphql/rejoiner/SchemaBundleTest.java
+++ b/rejoiner/src/test/java/com/google/api/graphql/rejoiner/SchemaBundleTest.java
@@ -1,0 +1,29 @@
+package com.google.api.graphql.rejoiner;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import graphql.Scalars;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import org.junit.Test;
+
+public class SchemaBundleTest {
+    @Test
+    public void createSchemaUsingSchemaBundle() {
+        final SchemaBundle.Builder schemaBuilder = AutoValue_SchemaBundle.builder();
+        schemaBuilder.modificationsBuilder().add(
+                Type.find("inner").addField(GraphQLFieldDefinition.newFieldDefinition()
+                        .name("bazinga")
+                        .type(Scalars.GraphQLBigInteger)
+                        .build()));
+        schemaBuilder.queryFieldsBuilder().add(GraphQLFieldDefinition.newFieldDefinition()
+                .name("bazinga")
+                .type(GraphQLObjectType.newObject().name("inner"))
+                .build());
+        final SchemaBundle schemaBundle = schemaBuilder.build();
+        final GraphQLSchema schema = schemaBundle.toSchema();
+        assertThat(schema.getQueryType().getFieldDefinitions()).hasSize(1);
+        assertThat(schema.getQueryType().getFieldDefinitions().get(0).getName()).isEqualTo("bazinga");
+    }
+}

--- a/rejoiner/src/test/java/com/google/api/graphql/rejoiner/SchemaBundleTest.java
+++ b/rejoiner/src/test/java/com/google/api/graphql/rejoiner/SchemaBundleTest.java
@@ -9,21 +9,28 @@ import graphql.schema.GraphQLSchema;
 import org.junit.Test;
 
 public class SchemaBundleTest {
-    @Test
-    public void createSchemaUsingSchemaBundle() {
-        final SchemaBundle.Builder schemaBuilder = AutoValue_SchemaBundle.builder();
-        schemaBuilder.modificationsBuilder().add(
-                Type.find("inner").addField(GraphQLFieldDefinition.newFieldDefinition()
+  @Test
+  public void createSchemaUsingSchemaBundle() {
+    final SchemaBundle.Builder schemaBuilder = AutoValue_SchemaBundle.builder();
+    schemaBuilder
+        .modificationsBuilder()
+        .add(
+            Type.find("inner")
+                .addField(
+                    GraphQLFieldDefinition.newFieldDefinition()
                         .name("bazinga")
                         .type(Scalars.GraphQLBigInteger)
                         .build()));
-        schemaBuilder.queryFieldsBuilder().add(GraphQLFieldDefinition.newFieldDefinition()
+    schemaBuilder
+        .queryFieldsBuilder()
+        .add(
+            GraphQLFieldDefinition.newFieldDefinition()
                 .name("bazinga")
                 .type(GraphQLObjectType.newObject().name("inner"))
                 .build());
-        final SchemaBundle schemaBundle = schemaBuilder.build();
-        final GraphQLSchema schema = schemaBundle.toSchema();
-        assertThat(schema.getQueryType().getFieldDefinitions()).hasSize(1);
-        assertThat(schema.getQueryType().getFieldDefinitions().get(0).getName()).isEqualTo("bazinga");
-    }
+    final SchemaBundle schemaBundle = schemaBuilder.build();
+    final GraphQLSchema schema = schemaBundle.toSchema();
+    assertThat(schema.getQueryType().getFieldDefinitions()).hasSize(1);
+    assertThat(schema.getQueryType().getFieldDefinitions().get(0).getName()).isEqualTo("bazinga");
+  }
 }


### PR DESCRIPTION
This separates the schema logic from the guice modules.
SchemaBundle could get a bunch of utility methods to make it easy to programmatically define a schema.
A few more tests are needed though the existing tests already cover this code.