### PR TITLE
Fix CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ before_install:
   - sed -i 's#/usr/local/bin/protoc#/tmp/protobuf/bin/protoc#g' rejoiner/pom.xml
   - sed -i 's#/usr/local/bin/protoc#/tmp/protobuf/bin/protoc#g' rejoiner-grpc/pom.xml
   - sed -i 's#/usr/local/bin/protoc#/tmp/protobuf/bin/protoc#g' rejoiner-guice/pom.xml
-  - sed -i 's#/usr/local/bin/protoc#/tmp/protobuf/bin/protoc#g' rejoiner-schema/pom.xml
+  - sed -i 's#/usr/local/bin/protoc#/tmp/protobuf/bin/protoc#g' schema/common/pom.xml
+  - sed -i 's#/usr/local/bin/protoc#/tmp/protobuf/bin/protoc#g' schema/firestore/pom.xml
   - ./travis_before_install.sh # build protoc into /tmp/protobuf
 
 install:


### PR DESCRIPTION
build failed on master branch

```
sed: can't read rejoiner-schema/pom.xml: No such file or directory
The command "sed -i 's#/usr/local/bin/protoc#/tmp/protobuf/bin/protoc#g' rejoiner-schema/pom.xml" failed and exited with 2 during .
```

https://travis-ci.org/google/rejoiner/builds/638037210#L207-L208