### PR TITLE
returning bytes as a utf8-encoded string

### DIFF
--- a/rejoiner-guice/src/test/java/com/google/api/graphql/rejoiner/RejoinerIntegrationTest.java
+++ b/rejoiner-guice/src/test/java/com/google/api/graphql/rejoiner/RejoinerIntegrationTest.java
@@ -276,7 +276,7 @@ public final class RejoinerIntegrationTest {
                         .put("intField", (long) 1)
                         .put("RenamedField", "name")
                         .put("testInnerProto", ImmutableMap.of("foo", "foooo"))
-                        .put("bytesField", ByteString.copyFromUtf8("b-y-t-e-s"))
+                        .put("bytesField", "b-y-t-e-s")
                         .build())));
   }
 

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/ProtoScalars.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/ProtoScalars.java
@@ -81,12 +81,12 @@ public final class ProtoScalars {
   public static final GraphQLScalarType BYTES =
       GraphQLScalarType.newScalar()
           .coercing(
-              new Coercing<ByteString, ByteString>() {
+              new Coercing<ByteString, String>() {
                 @Override
-                public ByteString serialize(Object dataFetcherResult)
+                public String serialize(Object dataFetcherResult)
                     throws CoercingSerializeException {
                   if (dataFetcherResult instanceof ByteString) {
-                    return (ByteString) dataFetcherResult;
+                    return ((ByteString) dataFetcherResult).toStringUtf8();
                   } else {
                     throw new CoercingSerializeException(
                         "Invalid value '" + dataFetcherResult + "' for Bytes");
@@ -119,7 +119,7 @@ public final class ProtoScalars {
               })
           .name("Bytes")
           .description(
-              "Scalar for proto type bytes."
+              "Scalar for proto type byte as a utf8-encoded string"
                   + " May contain any arbitrary sequence of bytes no longer than 2^32.")
           .build();
 }


### PR DESCRIPTION
Currently bytes are returned as an array of bytes, which gets transferred as an array of numbers in Json. 
<img width="731" alt="Before" src="https://user-images.githubusercontent.com/1284223/79020226-1ee09180-7b2d-11ea-8d61-d273d8d182f1.png">


This pr changes so the input and the output for Bytes is expected to be utf-8 encoded string

<img width="724" alt="After" src="https://user-images.githubusercontent.com/1284223/79020315-66671d80-7b2d-11ea-89a7-bb4698221c11.png">


