### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -1,4 +1,8 @@
 const siteConfig = {
+  algolia: {
+    apiKey: '0cd38f3b9cf50238665b8981b9709451',
+    indexName: 'rejoiner',
+  },
   title: 'Rejoiner',
   tagline: 'Uniform GraphQL schema from gRPC microservices',
   url: 'https://rejoiner.io',


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.