### PR TITLE
readme: code example and the description are provided to be the same

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ mutations, and schema modifications are presented below.
 ```java
 final class TodoQuerySchemaModule extends SchemaModule {
   @Query("listTodo")
-  ListenableFuture<ListTodoResponse> listTodo(ListTodoRequest request, TodoClient todoClient) {
-    return todoClient.listTodo(request);
+  ListenableFuture<ListTodoResponse> listTodo(ListTodoRequest request, TodoService todoService) {
+    return todoService.listTodo(request);
   }
 }
 ```


### PR DESCRIPTION
In the readme statement says `todoService isn't a protobuf message, so it's provided by the Guice injector.` but in the code, todoClient is given as a parameter instead of todoService. I just made sure that the correct parameter was used